### PR TITLE
feat: test for generating substrait from adhoc sql/ibis

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,24 +217,24 @@ Copy your Ibis expression into `substrait_consumer/tests/adhoc/ibis_expr.py`
 Run using the following command:
 ```commandline
 cd substrait_consumer/tests/adhoc
-pytest test_adhoc_expression.py
+pytest --adhoc_producer=IsthmusProducer test_adhoc_expression.py
 ```
 
-In addition to running the plans against the consumers, you can also save the 
+In addition to running the plans against the consumers, you can save the 
 produced substrait plans by specifying the `--saveplan` option.
 ```commandline
-pytest --saveplan test_adhoc_expression.py
+pytest --saveplan True --adhoc_producer=IsthmusProducer test_adhoc_expression.py
 ```
 Plans will be saved as {producer_name}_substrait.json
 ```commandline
 ls *.json
-DuckDBProducer_substrait.json	IbisProducer_substrait.json	IsthmusProducer_substrait.json
+IsthmusProducer_substrait.json
 ```
 
-If you want to only generate plans from a specific producer or run the plans against a
-specific consumer, you can also use the `--producer` and `--consumer` options.
+If you want to run the tests from specific producer/consumer pairs, you can use 
+the `--adhoc_producer` and `--consumer` options.
 ```commandline
-pytest --producer=IsthmusProducer --consumer=AceroConsumer test_adhoc_expression.py
+pytest --adhoc_producer=IsthmusProducer --consumer=AceroConsumer test_adhoc_expression.py
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ Table of Contents
   * [Test Case Args](#Test-Case-Args)
   * [SQL Queries](#SQL-Queries)
   * [Ibis Expressions](#Ibis-Expressions)
+* [CLI Tool](#Generating-Substrait-from-Adhoc-SQL-Ibis)
+  * [How to Use](#How-to-Use)
 * [How to Add Producers](#How-to-Add-Producers)
 * [How to Add Consumers](#How-to-Add-Consumers)
 
 
 # Overview
 This testing repository provides instructions on how to add and run substrait integration 
-tests.  The tests are organized into two categories; tpch tests (which test common benchmark queries) 
+tests as well as a CLI tool for generating substrait plans from adhoc SQL queries.  
+
+The tests are organized into two categories; tpch tests (which test common benchmark queries) 
 and substrait function tests (which test individual extension functions). Test data is created 
 using DuckDB at the start of the test class using the `prepare_tpch_parquet_data` fixture, 
 which is located in `substrait_consumer/conftest.py`.
@@ -197,6 +201,43 @@ IBIS_SCALAR = {
     "add": add_expr,
 }
 ```
+
+# Generating Substrait from Adhoc SQL/Ibis
+The CLI tool for generating substrait plans from adhoc SQL queries and Ibis expression
+is located in the `substrait_consumer/tests/adhoc` directory.  The SQL queries should be 
+written using the same TPCH data used in the integration tests.  This tool will generate 
+the substrait plans for each supported producer and run that plan against all supported consumers.
+
+## How to Use
+Copy your SQL query into `substrait_consumer/tests/adhoc/query.sql`.  
+Copy your Ibis expression into `substrait_consumer/tests/adhoc/ibis_expr.py`
+
+*Note: The test expects a specific name for the ibis expression as well as the named tables being passed to it. This is line 1 of ibis_expr.py, and it should not be modified.
+
+Run using the following command:
+```commandline
+cd substrait_consumer/tests/adhoc
+pytest test_adhoc_expression.py
+```
+
+In addition to running the plans against the consumers, you can also save the 
+produced substrait plans by specifying the `--saveplan` option.
+```commandline
+pytest --saveplan test_adhoc_expression.py
+```
+Plans will be saved as {producer_name}_substrait.json
+```commandline
+ls *.json
+DuckDBProducer_substrait.json	IbisProducer_substrait.json	IsthmusProducer_substrait.json
+```
+
+If you want to only generate plans from a specific producer or run the plans against a
+specific consumer, you can also use the `--producer` and `--consumer` options.
+```commandline
+pytest --producer=IsthmusProducer --consumer=AceroConsumer test_adhoc_expression.py
+```
+
+
 
 # How to Add Producers
 Producers should be added to the `substrait_consumer/producers.py` file and provide 

--- a/README.md
+++ b/README.md
@@ -209,19 +209,23 @@ written using the same TPCH data used in the integration tests.  This tool will 
 the substrait plans for each supported producer and run that plan against all supported consumers.
 
 ## How to Use
-Copy your SQL query into `substrait_consumer/tests/adhoc/query.sql`.  
-Copy your Ibis expression into `substrait_consumer/tests/adhoc/ibis_expr.py`
-
-*Note: The test expects a specific name for the ibis expression as well as the named tables being passed to it. This is line 1 of ibis_expr.py, and it should not be modified.
-
-Run using the following command:
+If you are testing out an SQL query, copy your SQL query into `substrait_consumer/tests/adhoc/query.sql`
+and run the following command (make sure to specify a producer that can convert SQL to Substrait):
 ```commandline
 cd substrait_consumer/tests/adhoc
 pytest --adhoc_producer=IsthmusProducer test_adhoc_expression.py
 ```
 
-In addition to running the plans against the consumers, you can save the 
-produced substrait plans by specifying the `--saveplan` option.
+If you are testing out an Ibis expression, copy your Ibis expression into 
+`substrait_consumer/tests/adhoc/ibis_expr.py` and run the following command:
+```commandline
+cd substrait_consumer/tests/adhoc
+pytest --adhoc_producer=IbisProducer test_adhoc_expression.py
+```
+*Note: If you're using the IbisProducer, make sure you do not edit the function name and arguments
+already in line 2 of `ibis_expr.py`.  The test is expecting the specific name and arguments.
+
+You can save the produced substrait plans with the `--saveplan` option.
 ```commandline
 pytest --saveplan True --adhoc_producer=IsthmusProducer test_adhoc_expression.py
 ```
@@ -231,8 +235,8 @@ ls *.json
 IsthmusProducer_substrait.json
 ```
 
-If you want to run the tests from specific producer/consumer pairs, you can use 
-the `--adhoc_producer` and `--consumer` options.
+If you want to run the tests using specific producer/consumer pairs, you can use 
+the both the `--adhoc_producer` and `--consumer` options.
 ```commandline
 pytest --adhoc_producer=IsthmusProducer --consumer=AceroConsumer test_adhoc_expression.py
 ```

--- a/substrait_consumer/conftest.py
+++ b/substrait_consumer/conftest.py
@@ -41,6 +41,17 @@ def pytest_addoption(parser):
         help="A comma separated list of producers to run against.",
         choices=[x.__name__ for x in PRODUCERS]
     )
+    parser.addoption(
+        "--saveplan",
+        action="store",
+        default=False,
+        help="Save the substrait plans created by each producer."
+    )
+
+
+@pytest.fixture
+def saveplan(request):
+    return request.config.getoption("--saveplan")
 
 
 PRODUCERS = [DuckDBProducer, IbisProducer, IsthmusProducer]

--- a/substrait_consumer/conftest.py
+++ b/substrait_consumer/conftest.py
@@ -44,7 +44,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--adhoc_producer",
         action="store",
-        default=",".join([x.__name__ for x in []]),
+        default="",
         help="A comma separated list of producers to run against.",
         choices=[x.__name__ for x in PRODUCERS]
     )

--- a/substrait_consumer/conftest.py
+++ b/substrait_consumer/conftest.py
@@ -42,6 +42,13 @@ def pytest_addoption(parser):
         choices=[x.__name__ for x in PRODUCERS]
     )
     parser.addoption(
+        "--adhoc_producer",
+        action="store",
+        default=",".join([x.__name__ for x in []]),
+        help="A comma separated list of producers to run against.",
+        choices=[x.__name__ for x in PRODUCERS]
+    )
+    parser.addoption(
         "--saveplan",
         action="store",
         default=False,
@@ -82,6 +89,19 @@ def consumer(request):
 @pytest.fixture(params=_get_producers(), scope="session")
 def producer(request):
     producers_list = request.config.option.producer.split(",")
+    producer = request.param()
+    if type(producer).__name__ in producers_list:
+        return producer
+    else:
+        pytest.skip(
+            f"Skipping producer: '{type(producer).__name__})', "
+            f"the specified producers are: {producers_list}"
+        )
+
+
+@pytest.fixture(params=_get_producers(), scope="session")
+def adhoc_producer(request):
+    producers_list = request.config.option.adhoc_producer.split(",")
     producer = request.param()
     if type(producer).__name__ in producers_list:
         return producer

--- a/substrait_consumer/tests/adhoc/ibis_expr.py
+++ b/substrait_consumer/tests/adhoc/ibis_expr.py
@@ -1,0 +1,3 @@
+def ibis_expr(part, supplier, partsupp, customer, orders, lineitem, nation, region):
+    proj = lineitem[lineitem]
+    return proj

--- a/substrait_consumer/tests/adhoc/ibis_expr.py
+++ b/substrait_consumer/tests/adhoc/ibis_expr.py
@@ -1,3 +1,4 @@
+# Do not edit line 2.  The function name and arguments are expected for this test.
 def ibis_expr(part, supplier, partsupp, customer, orders, lineitem, nation, region):
     proj = lineitem[lineitem]
     return proj

--- a/substrait_consumer/tests/adhoc/query.sql
+++ b/substrait_consumer/tests/adhoc/query.sql
@@ -1,0 +1,1 @@
+SELECT * FROM lineitem

--- a/substrait_consumer/tests/adhoc/test_adhoc_expression.py
+++ b/substrait_consumer/tests/adhoc/test_adhoc_expression.py
@@ -1,0 +1,103 @@
+import json
+from pathlib import Path
+
+import duckdb
+from ibis_substrait.tests.compiler.conftest import *
+
+from substrait_consumer.tests.adhoc.ibis_expr import ibis_expr
+from substrait_consumer.verification import verify_equals
+
+CUR_DIR = Path(__file__).parent
+SQL_FILE_PATH = CUR_DIR / "query.sql"
+
+
+FILE_NAMES = [
+    "customer.parquet",
+    "lineitem.parquet",
+    "nation.parquet",
+    "orders.parquet",
+    "part.parquet",
+    "partsupp.parquet",
+    "region.parquet",
+    "supplier.parquet",
+]
+
+
+@pytest.mark.usefixtures("prepare_tpch_parquet_data")
+class TestAdhocExpression:
+    """
+    Test CLI for generating substrait plans from adhoc SQL queries or ibis expressions
+    and testing them against different consumers.
+    """
+
+    @staticmethod
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_teardown_class(request):
+        cls = request.cls
+        cls.produced_plans = set()
+
+    @staticmethod
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_teardown_function(request):
+        cls = request.cls
+
+        cls.db_connection = duckdb.connect()
+        cls.db_connection.execute("install substrait")
+        cls.db_connection.execute("load substrait")
+
+        yield
+
+        cls.db_connection.close()
+
+    def test_adhoc_expression(
+        self,
+        producer,
+        consumer,
+        saveplan,
+        part,
+        supplier,
+        partsupp,
+        customer,
+        orders,
+        lineitem,
+        nation,
+        region,
+    ) -> None:
+        producer.set_db_connection(self.db_connection)
+        consumer.setup(self.db_connection, FILE_NAMES)
+
+        with open(SQL_FILE_PATH, "r") as f:
+            sql_query = f.read()
+
+        if not sql_query:
+            raise ValueError("No SQL query.  Please write SQL into query.sql")
+        sql_query = producer.format_sql(set(), sql_query, FILE_NAMES)
+        substrait_plan = producer.produce_substrait(
+            sql_query,
+            consumer,
+            ibis_expr(
+                part, supplier, partsupp, customer, orders, lineitem, nation, region
+            ),
+        )
+        producer_name = type(producer).__name__
+        if isinstance(substrait_plan, str) and saveplan:
+            if producer_name not in self.produced_plans:
+                self.produced_plans.add(producer_name)
+                python_json = json.loads(substrait_plan)
+                with open(f"{producer_name}_substrait.json", "w") as outfile:
+                    outfile.write(json.dumps(python_json, indent=4))
+            else:
+                pytest.skip(
+                    f"Plan already produced using the producer: {producer_name}"
+                )
+
+        actual_result = consumer.run_substrait_query(substrait_plan)
+        expected_result = self.db_connection.query(f"{sql_query}").arrow()
+
+        verify_equals(
+            actual_result.columns,
+            expected_result.columns,
+            message=f"Result: {actual_result.columns} "
+            f"is not equal to the expected: "
+            f"{expected_result.columns}",
+        )

--- a/substrait_consumer/tests/adhoc/test_adhoc_expression.py
+++ b/substrait_consumer/tests/adhoc/test_adhoc_expression.py
@@ -51,7 +51,7 @@ class TestAdhocExpression:
 
     def test_adhoc_expression(
         self,
-        producer,
+        adhoc_producer,
         consumer,
         saveplan,
         part,
@@ -63,7 +63,7 @@ class TestAdhocExpression:
         nation,
         region,
     ) -> None:
-        producer.set_db_connection(self.db_connection)
+        adhoc_producer.set_db_connection(self.db_connection)
         consumer.setup(self.db_connection, FILE_NAMES)
 
         with open(SQL_FILE_PATH, "r") as f:
@@ -71,15 +71,15 @@ class TestAdhocExpression:
 
         if not sql_query:
             raise ValueError("No SQL query.  Please write SQL into query.sql")
-        sql_query = producer.format_sql(set(), sql_query, FILE_NAMES)
-        substrait_plan = producer.produce_substrait(
+        sql_query = adhoc_producer.format_sql(set(), sql_query, FILE_NAMES)
+        substrait_plan = adhoc_producer.produce_substrait(
             sql_query,
             consumer,
             ibis_expr(
                 part, supplier, partsupp, customer, orders, lineitem, nation, region
             ),
         )
-        producer_name = type(producer).__name__
+        producer_name = type(adhoc_producer).__name__
         if isinstance(substrait_plan, str) and saveplan:
             if producer_name not in self.produced_plans:
                 self.produced_plans.add(producer_name)

--- a/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
@@ -45,7 +45,6 @@ class TestBooleanFunctions:
         ibis_expr: Callable[[Table], Table],
         producer,
         consumer,
-        partsupp
     ) -> None:
         substrait_function_test(
             self.db_connection,
@@ -55,6 +54,5 @@ class TestBooleanFunctions:
             ibis_expr,
             producer,
             consumer,
-            partsupp,
             self.table_t,
         )


### PR DESCRIPTION
test for generating substrait plans from supported producers when given a SQL query or Ibis expression.  Substrait plans can be run against supported consumers as well.

Option to save substrait plan from each producer as json output.