### PR TITLE
chore: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: gitsubmodule
+    schedule:
+        interval: "daily"
+    directory: /


### PR DESCRIPTION
Add dependabot.yaml to automatically update the substrait-java submodule