### PR TITLE
Fix: fix test results path in streamlit app python script

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -3,7 +3,7 @@ Substrait Producer and Consumer Function Support
 
 # Substrait Producer Function Support Matrix
 
-[Substrait Producer x Function](https://consumer-testing-crahxzgvruqwmujgry3r2u.streamlit.app/)
+[Substrait Producer x Function](https://substrait-function-compatibility.streamlit.app/)
 
 [Raw table of test results](https://github.com/substrait-io/consumer-testing/blob/main/app/producer_results.csv)
 
@@ -22,7 +22,7 @@ python parse_producer_pytest_output.py producer_results.csv
 
 # Substrait Producer x Consumer x Function Support Matrix
 
-[Substrait Producer x Substrait Consumer x Function](https://consumer-testing-qomfxmpyspcrpkatq3uz3g.streamlit.app/)
+[Substrait Producer x Substrait Consumer x Function](https://substrait-consumer-compatibility.streamlit.app/)
 
 [Raw table of test results](https://github.com/substrait-io/consumer-testing/blob/main/app/consumer_results.csv)
 

--- a/app/substrait_consumer_function_compatibility.py
+++ b/app/substrait_consumer_function_compatibility.py
@@ -10,7 +10,9 @@ st.set_page_config(layout="wide")
 
 def support_matrix_df():
     return (
-        ibis.read_csv("./consumer_results.csv")
+        ibis.read_csv(
+            "https://raw.githubusercontent.com/substrait-io/consumer-testing/main/app/consumer_results.csv"
+        )
         .rename({"full_function": "FullFunction"})
         .mutate(
             function_category=_.full_function.split(".")[-2],

--- a/app/substrait_producer_function_compatibility.py
+++ b/app/substrait_producer_function_compatibility.py
@@ -10,7 +10,9 @@ st.set_page_config(layout="wide")
 
 def support_matrix_df():
     return (
-        ibis.read_csv("./producer_results.csv")
+        ibis.read_csv(
+            "https://raw.githubusercontent.com/substrait-io/consumer-testing/main/app/producer_results.csv"
+        )
         .rename({"full_operation": "FullFunction"})
         .mutate(
             function_category=_.full_operation.split(".")[-2],


### PR DESCRIPTION
Test results path needs to be a url in order for streamlit to be able to read it
since streamlit is a third party app.