### PR TITLE
fix: add aceroconsumer back to conftest

### DIFF
--- a/substrait_consumer/conftest.py
+++ b/substrait_consumer/conftest.py
@@ -67,7 +67,7 @@ def saveplan(request):
 
 
 PRODUCERS = [DataFusionProducer, DuckDBProducer, IbisProducer, IsthmusProducer]
-CONSUMERS = [DataFusionConsumer, DuckDBConsumer]
+CONSUMERS = [AceroConsumer, DataFusionConsumer, DuckDBConsumer]
 
 
 def _get_consumers():


### PR DESCRIPTION
Adding back the AceroConsumer to conftest so it can be tested with