### PR TITLE
feat: add ddl relation tests

### DIFF
--- a/substrait_consumer/functional/ddl_relation_configs.py
+++ b/substrait_consumer/functional/ddl_relation_configs.py
@@ -21,15 +21,15 @@ DDL_RELATION_TESTS = (
         "ibis_expr": None
     },
     {
-        "test_name": "alter_columnn",
+        "test_name": "alter_column",
         "file_names": ["customer.parquet"],
-        "sql_query": DDL_RELATIONS["alter_columnn"],
+        "sql_query": DDL_RELATIONS["alter_column"],
         "ibis_expr": None
     },
     {
-        "test_name": "drop_columnn",
+        "test_name": "drop_column",
         "file_names": ["customer.parquet"],
-        "sql_query": DDL_RELATIONS["drop_columnn"],
+        "sql_query": DDL_RELATIONS["drop_column"],
         "ibis_expr": None
     },
     {

--- a/substrait_consumer/functional/ddl_relation_configs.py
+++ b/substrait_consumer/functional/ddl_relation_configs.py
@@ -1,0 +1,47 @@
+from substrait_consumer.functional.queries.sql.relations.ddl_relations import (
+    DDL_RELATIONS)
+
+DDL_RELATION_TESTS = (
+    {
+        "test_name": "create_table",
+        "file_names": [],
+        "sql_query": DDL_RELATIONS["create_table"],
+        "ibis_expr": None
+    },
+    {
+        "test_name": "drop_table",
+        "file_names": ["customer.parquet"],
+        "sql_query": DDL_RELATIONS["drop_table"],
+        "ibis_expr": None
+    },
+    {
+        "test_name": "alter_table",
+        "file_names": ["customer.parquet"],
+        "sql_query": DDL_RELATIONS["alter_table"],
+        "ibis_expr": None
+    },
+    {
+        "test_name": "alter_columnn",
+        "file_names": ["customer.parquet"],
+        "sql_query": DDL_RELATIONS["alter_columnn"],
+        "ibis_expr": None
+    },
+    {
+        "test_name": "drop_columnn",
+        "file_names": ["customer.parquet"],
+        "sql_query": DDL_RELATIONS["drop_columnn"],
+        "ibis_expr": None
+    },
+    {
+        "test_name": "create_view",
+        "file_names": ["customer.parquet"],
+        "sql_query": DDL_RELATIONS["create_view"],
+        "ibis_expr": None
+    },
+    {
+        "test_name": "create_or_replace_view",
+        "file_names": ["customer.parquet"],
+        "sql_query": DDL_RELATIONS["create_or_replace_view"],
+        "ibis_expr": None
+    },
+)

--- a/substrait_consumer/functional/queries/sql/relations/ddl_relations.py
+++ b/substrait_consumer/functional/queries/sql/relations/ddl_relations.py
@@ -26,14 +26,14 @@ DDL_RELATIONS = {
         """,
         [DuckDBProducer, DataFusionProducer, IsthmusProducer],
     ),
-    "alter_columnn": (
+    "alter_column": (
         """
         ALTER TABLE '{}'
         RENAME COLUMN c_address TO c_street_address;
         """,
         [DuckDBProducer, DataFusionProducer, IsthmusProducer],
     ),
-    "drop_columnn": (
+    "drop_column": (
         """
         ALTER TABLE '{}'
         DROP COLUMN c_address;

--- a/substrait_consumer/functional/queries/sql/relations/ddl_relations.py
+++ b/substrait_consumer/functional/queries/sql/relations/ddl_relations.py
@@ -1,0 +1,65 @@
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.isthmus_producer import IsthmusProducer
+
+DDL_RELATIONS = {
+    "create_table": (
+        """
+        CREATE TABLE customer2 (
+            custkey INT NOT NULL,
+            name VARCHAR NOT NULL,
+            address VARCHAR NOT NULL,
+        )
+        """,
+        [DuckDBProducer, DataFusionProducer, IsthmusProducer],
+    ),
+    "drop_table": (
+        """
+        DROP TABLE '{}';
+        """,
+        [DuckDBProducer, DataFusionProducer, IsthmusProducer],
+    ),
+    "alter_table": (
+        """
+        ALTER TABLE '{}'
+        ADD email VARCHAR;
+        """,
+        [DuckDBProducer, DataFusionProducer, IsthmusProducer],
+    ),
+    "alter_columnn": (
+        """
+        ALTER TABLE '{}'
+        RENAME COLUMN c_address TO c_street_address;
+        """,
+        [DuckDBProducer, DataFusionProducer, IsthmusProducer],
+    ),
+    "drop_columnn": (
+        """
+        ALTER TABLE '{}'
+        DROP COLUMN c_address;
+        """,
+        [DuckDBProducer, DataFusionProducer, IsthmusProducer],
+    ),
+    "create_view": (
+        """
+        CREATE VIEW customer_view AS
+        SELECT 
+            C_CUSTKEY,
+            C_NAME,
+        FROM 
+            '{}';
+        """,
+        [DuckDBProducer, DataFusionProducer, IsthmusProducer],
+    ),
+    "create_or_replace_view": (
+        """
+        CREATE OR REPLACE VIEW customer_view AS
+        SELECT 
+            C_CUSTKEY,
+            C_NAME,
+        FROM 
+            '{}';
+        """,
+        [DuckDBProducer, DataFusionProducer, IsthmusProducer],
+    ),
+}

--- a/substrait_consumer/tests/functional/relations/test_ddl_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_ddl_relation.py
@@ -1,0 +1,105 @@
+from typing import Callable, Iterable
+
+import duckdb
+from ibis.expr.types.relations import Table
+from ibis_substrait.tests.compiler.conftest import *
+
+from substrait_consumer.functional.ddl_relation_configs import (
+    DDL_RELATION_TESTS)
+from substrait_consumer.functional.common import (
+    generate_snapshot_results,
+    substrait_consumer_sql_test, substrait_producer_sql_test)
+from substrait_consumer.parametrization import custom_parametrization
+
+
+@pytest.fixture
+def mark_producer_tests_as_xfail(request):
+    """Marks a subset of tests as expected to be fail."""
+    test_case_name = request.node.callspec.id.split('-')[-1]
+    if test_case_name in ["create_table", "drop_table", "alter_table", "alter_columnn",
+                          "drop_columnn", "create_view", "create_or_replace_view"]:
+        pytest.skip(reason='Creating substrait plans with write relations is not supported')
+
+
+@pytest.fixture
+def mark_consumer_tests_as_xfail(request):
+    """Marks a subset of tests as expected to be fail."""
+    test_case_name = request.node.callspec.id.split('-')[-1]
+    if test_case_name in ["create_table", "drop_table", "alter_table", "alter_columnn",
+                          "drop_columnn", "create_view", "create_or_replace_view"]:
+        pytest.skip(reason='Creating substrait plans with write relations is not supported')
+
+
+@pytest.mark.usefixtures("prepare_tpch_parquet_data")
+class TestDDLRelation:
+    """
+    Test Class verifying different consumers are able to run substrait plans
+    that include substrait sort relations.
+    """
+
+    @staticmethod
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_teardown_class(request):
+        cls = request.cls
+
+        cls.db_connection = duckdb.connect()
+        cls.db_connection.execute("install substrait")
+        cls.db_connection.execute("load substrait")
+        cls.created_tables = set()
+
+        yield
+
+        cls.db_connection.close()
+
+    @custom_parametrization(DDL_RELATION_TESTS)
+    @pytest.mark.produce_substrait_snapshot
+    @pytest.mark.usefixtures('mark_producer_tests_as_xfail')
+    def test_producer_ddl_relations(
+        self,
+        snapshot,
+        test_name: str,
+        file_names: Iterable[str],
+        sql_query: tuple,
+        ibis_expr: Callable[[Table], Table],
+        producer,
+        partsupp
+    ) -> None:
+        test_name = f"ddl_relation_snapshots:{test_name}"
+        substrait_producer_sql_test(
+            test_name,
+            snapshot,
+            self.db_connection,
+            self.created_tables,
+            file_names,
+            sql_query,
+            ibis_expr,
+            producer,
+            partsupp,
+            validate=True
+        )
+
+    @custom_parametrization(DDL_RELATION_TESTS)
+    @pytest.mark.consume_substrait_snapshot
+    @pytest.mark.usefixtures('mark_consumer_tests_as_xfail')
+    def test_consumer_ddl_relations(
+        self,
+        snapshot,
+        test_name: str,
+        file_names: Iterable[str],
+        sql_query: tuple,
+        ibis_expr: Callable[[Table], Table],
+        producer,
+        consumer,
+    ) -> None:
+        test_name = f"ddl_relation_snapshots:{test_name}"
+        substrait_consumer_sql_test(
+            test_name,
+            snapshot,
+            self.db_connection,
+            self.created_tables,
+            file_names,
+            sql_query,
+            ibis_expr,
+            producer,
+            consumer,
+        )


### PR DESCRIPTION
tests are marked to be skipped for now since no producers can generate
substrait plans properly