### PR TITLE
fix: remove tracking of existing tables in `created_tables`

### DIFF
--- a/substrait_consumer/consumers/acero_consumer.py
+++ b/substrait_consumer/consumers/acero_consumer.py
@@ -22,17 +22,12 @@ class AceroConsumer(Consumer):
         self.tables = {}
         self.table_provider = lambda names, schema: self.tables[names[0].lower()]
 
-    def setup(self, db_connection, created_tables, file_names: Iterable[str]):
+    def setup(self, db_connection, file_names: Iterable[str]):
         if len(file_names) > 0:
             parquet_file_paths = SubstraitUtils.get_full_path(file_names)
             for file_name, file_path in zip(file_names, parquet_file_paths):
                 table_name = Path(file_name).stem
-                table_name = table_name.translate(
-                    str.maketrans("", "", string.punctuation)
-                )
-                if f"{self.__class__.__name__}{table_name}" not in created_tables:
-                    created_tables.add(f"{self.__class__.__name__}{table_name}")
-                    self.tables[table_name] = pq.read_table(file_path)
+                self.tables[table_name] = pq.read_table(file_path)
         else:
             table = pa.table(
                 {

--- a/substrait_consumer/consumers/consumer.py
+++ b/substrait_consumer/consumers/consumer.py
@@ -35,7 +35,7 @@ COLUMN_D = [
 
 class Consumer(ABC):
     @abstractmethod
-    def setup(self, db_connection, created_tables, file_names: Iterable[str]):
+    def setup(self, db_connection, file_names: Iterable[str]):
         pass
 
     @abstractmethod

--- a/substrait_consumer/consumers/datafusion_consumer.py
+++ b/substrait_consumer/consumers/datafusion_consumer.py
@@ -24,14 +24,14 @@ class DataFusionConsumer(Consumer):
     def __init__(self):
         self._ctx = SessionContext()
 
-    def setup(self, db_connection, created_tables, file_names: Iterable[str]):
+    def setup(self, db_connection, file_names: Iterable[str]):
         if len(file_names) > 0:
             parquet_file_paths = SubstraitUtils.get_full_path(file_names)
             for file_name, file_path in zip(file_names, parquet_file_paths):
                 table_name = Path(file_name).stem
-                if not self._ctx.table_exist(table_name):
-                    created_tables.add(table_name)
-                    self._ctx.register_parquet(table_name, file_path)
+                if self._ctx.table_exist(table_name):
+                    self._ctx.deregister_table(table_name)
+                self._ctx.register_parquet(table_name, file_path)
         else:
             if not self._ctx.table_exist("t"):
                 tables = pa.RecordBatch.from_arrays(

--- a/substrait_consumer/functional/common.py
+++ b/substrait_consumer/functional/common.py
@@ -51,7 +51,6 @@ def generate_snapshot_results(
     test_name: str,
     snapshot: Snapshot,
     db_con: DuckDBPyConnection,
-    created_tables: set,
     file_names: Iterable[str],
     sql_query: tuple,
 ):
@@ -66,8 +65,6 @@ def generate_snapshot_results(
             Pytest snapshot plugin used for verification.
         db_con:
             DuckDB connection for creating in memory tables.
-        created_tables:
-            Tables names that have already been created.
         file_names:
             List of parquet files.
         sql_query:
@@ -76,7 +73,7 @@ def generate_snapshot_results(
     # Load the parquet files into DuckDB and return all the table names as a list
     producer = DuckDBProducer()
     producer.set_db_connection(db_con)
-    sql_query = producer.format_sql(created_tables, sql_query[0], file_names)
+    sql_query = producer.format_sql(sql_query[0], file_names)
 
     duckdb_result = db_con.query(f"{sql_query}").arrow()
     duckdb_result = duckdb_result.rename_columns(
@@ -99,7 +96,6 @@ def substrait_producer_sql_test(
     test_name: str,
     snapshot: Snapshot,
     db_con: DuckDBPyConnection,
-    created_tables: set,
     file_names: Iterable[str],
     sql_query: tuple,
     ibis_expr: Callable[[Table], Table],
@@ -119,8 +115,6 @@ def substrait_producer_sql_test(
             Pytest snapshot plugin used for verification.
         db_con:
             DuckDB connection for creating in memory tables.
-        created_tables:
-            Tables names that have already been created.
         file_names:
             List of parquet files.
         sql_query:
@@ -136,7 +130,7 @@ def substrait_producer_sql_test(
     supported_producers = sql_query[1]
 
     # Load the parquet files into DuckDB and return all the table names as a list
-    sql_query = producer.format_sql(created_tables, sql_query[0], file_names)
+    sql_query = producer.format_sql(sql_query[0], file_names)
 
     # Convert the SQL/Ibis expression to a substrait query plan
     if type(producer).__name__ == "IbisProducer":
@@ -165,7 +159,6 @@ def substrait_consumer_sql_test(
     test_name: str,
     snapshot: Snapshot,
     db_con: DuckDBPyConnection,
-    created_tables: set,
     file_names: Iterable[str],
     sql_query: tuple,
     ibis_expr: Callable[[Table], Table],
@@ -184,8 +177,6 @@ def substrait_consumer_sql_test(
             Pytest snapshot plugin used for verification.
         db_con:
             DuckDB connection for creating in memory tables.
-        created_tables:
-            Tables names that have already been created.
         file_names:
             List of parquet files.
         sql_query:
@@ -197,7 +188,7 @@ def substrait_consumer_sql_test(
         consumer:
             Substrait consumer class.
     """
-    consumer.setup(db_con, created_tables, file_names)
+    consumer.setup(db_con, file_names)
 
     group, name = test_name.split(":")
     snopshot_dir = RELATION_SNAPSHOT_DIR if "relation" in group else FUNCTION_SNAPSHOT_DIR

--- a/substrait_consumer/producers/duckdb_producer.py
+++ b/substrait_consumer/producers/duckdb_producer.py
@@ -47,14 +47,14 @@ class DuckDBProducer(Producer):
         python_json = json.loads(proto_bytes)
         return json.dumps(python_json, indent=2)
 
-    def format_sql(self, created_tables, sql_query, file_names):
+    def format_sql(self, sql_query, file_names):
         if len(file_names) > 0:
             if "read_parquet" in sql_query:
                 parquet_file_path = SubstraitUtils.get_full_path(file_names)
                 sql_query = sql_query.format(parquet_file_path[0])
             else:
                 table_names = load_tables_from_parquet(
-                    self._db_connection, created_tables, file_names
+                    self._db_connection, file_names
                 )
                 sql_query = sql_query.format(*table_names)
         return sql_query

--- a/substrait_consumer/producers/ibis_producer.py
+++ b/substrait_consumer/producers/ibis_producer.py
@@ -42,10 +42,10 @@ class IbisProducer(Producer):
         substrait_plan = json_format.MessageToJson(tpch_proto_bytes)
         return substrait_plan
 
-    def format_sql(self, created_tables, sql_query, file_names):
+    def format_sql(self, sql_query, file_names):
         if len(file_names) > 0:
             table_names = load_tables_from_parquet(
-                self._db_connection, created_tables, file_names
+                self._db_connection, file_names
             )
             sql_query = sql_query.format(*table_names)
         return sql_query

--- a/substrait_consumer/producers/isthmus_producer.py
+++ b/substrait_consumer/producers/isthmus_producer.py
@@ -40,13 +40,13 @@ class IsthmusProducer(Producer):
 
         return substrait_plan_str
 
-    def format_sql(self, created_tables, sql_query, file_names):
+    def format_sql(self, sql_query, file_names):
         sql_query = sql_query.replace("'{}'", "{}")
         sql_query = sql_query.replace("'t'", "t")
         if len(file_names) > 0:
             self.file_names = file_names
             table_names = load_tables_from_parquet(
-                self._db_connection, created_tables, file_names
+                self._db_connection, file_names
             )
             sql_query = sql_query.format(*table_names)
         return sql_query

--- a/substrait_consumer/producers/producer.py
+++ b/substrait_consumer/producers/producer.py
@@ -16,13 +16,12 @@ class Producer(ABC):
         pass
 
     @abstractmethod
-    def format_sql(self, created_tables, sql_query, file_names):
+    def format_sql(self, sql_query, file_names):
         pass
 
 
 def load_tables_from_parquet(
     db_connection,
-    created_tables: set,
     file_names: Iterable[str],
 ) -> list:
     """
@@ -31,8 +30,6 @@ def load_tables_from_parquet(
     Parameters:
         db_connection:
             DuckDB Connection.
-        created_tables:
-            The set of tables that have already been created.
         file_names:
             Name of parquet files.
     Returns:
@@ -42,10 +39,12 @@ def load_tables_from_parquet(
     table_names = []
     for file_name, file_path in zip(file_names, parquet_file_paths):
         table_name = Path(file_name).stem
-        if table_name not in created_tables:
-            create_table_sql = f"CREATE TABLE {table_name} AS SELECT * FROM read_parquet('{file_path}');"
-            db_connection.execute(create_table_sql)
-            created_tables.add(table_name)
+        try:
+            db_connection.execute(f"DROP TABLE {table_name}")
+        except:
+            pass
+        create_table_sql = f"CREATE TABLE {table_name} AS SELECT * FROM read_parquet('{file_path}');"
+        db_connection.execute(create_table_sql)
         table_names.append(table_name)
 
     return table_names

--- a/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
@@ -44,7 +44,6 @@ class TestApproximationFunctions:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("INSTALL substrait")
         cls.db_connection.execute("LOAD substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -67,7 +66,6 @@ class TestApproximationFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -94,7 +92,6 @@ class TestApproximationFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -117,7 +114,6 @@ class TestApproximationFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
@@ -55,8 +55,6 @@ class TestArithmeticDecimalFunctions:
         cls.db_connection.execute("LOAD substrait")
         load_custom_duckdb_table(cls.db_connection)
 
-        cls.created_tables = set()
-
         yield
 
         cls.db_connection.close()
@@ -79,7 +77,6 @@ class TestArithmeticDecimalFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -106,7 +103,6 @@ class TestArithmeticDecimalFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -129,7 +125,6 @@ class TestArithmeticDecimalFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_functions.py
@@ -71,8 +71,6 @@ class TestArithmeticFunctions:
             name="t",
         )
 
-        cls.created_tables = set()
-
         yield
 
         cls.db_connection.close()
@@ -96,7 +94,6 @@ class TestArithmeticFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -124,7 +121,6 @@ class TestArithmeticFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -148,7 +144,6 @@ class TestArithmeticFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
@@ -46,8 +46,6 @@ class TestBooleanFunctions:
             name="t",
         )
 
-        cls.created_tables = set()
-
         yield
 
         cls.db_connection.close()
@@ -68,7 +66,6 @@ class TestBooleanFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -94,7 +91,6 @@ class TestBooleanFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -117,7 +113,6 @@ class TestBooleanFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
@@ -58,8 +58,6 @@ class TestComparisonFunctions:
         cls.db_connection.execute("load substrait")
         load_custom_duckdb_table(cls.db_connection)
 
-        cls.created_tables = set()
-
         yield
 
         cls.db_connection.close()
@@ -83,7 +81,6 @@ class TestComparisonFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -112,7 +109,6 @@ class TestComparisonFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -135,7 +131,6 @@ class TestComparisonFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
@@ -54,7 +54,6 @@ class TestDatetimeFunctions:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -78,7 +77,6 @@ class TestDatetimeFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -105,7 +103,6 @@ class TestDatetimeFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -128,7 +125,6 @@ class TestDatetimeFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
@@ -57,7 +57,6 @@ class TestLogarithmicFunctions:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -81,7 +80,6 @@ class TestLogarithmicFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -108,7 +106,6 @@ class TestLogarithmicFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -132,7 +129,6 @@ class TestLogarithmicFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
@@ -42,7 +42,6 @@ class TestRoundingFunctions:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -66,7 +65,6 @@ class TestRoundingFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -95,7 +93,6 @@ class TestRoundingFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -118,7 +115,6 @@ class TestRoundingFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/extension_functions/test_string_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_string_functions.py
@@ -53,7 +53,6 @@ class TestStringFunctions:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -78,7 +77,6 @@ class TestStringFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -107,7 +105,6 @@ class TestStringFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -130,7 +127,6 @@ class TestStringFunctions:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
@@ -40,7 +40,6 @@ class TestAggregatetRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -63,7 +62,6 @@ class TestAggregatetRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -90,7 +88,6 @@ class TestAggregatetRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -113,7 +110,6 @@ class TestAggregatetRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_ddl_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_ddl_relation.py
@@ -45,7 +45,6 @@ class TestDDLRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -69,7 +68,6 @@ class TestDDLRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -96,7 +94,6 @@ class TestDDLRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,

--- a/substrait_consumer/tests/functional/relations/test_fetch_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_fetch_relation.py
@@ -40,7 +40,6 @@ class TestFetchRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -63,7 +62,6 @@ class TestFetchRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -90,7 +88,6 @@ class TestFetchRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -113,7 +110,6 @@ class TestFetchRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_filter_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_filter_relation.py
@@ -43,7 +43,6 @@ class TestfilterRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -66,7 +65,6 @@ class TestfilterRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -93,7 +91,6 @@ class TestfilterRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -116,7 +113,6 @@ class TestfilterRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_join_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_join_relation.py
@@ -61,7 +61,6 @@ class TestJoinRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -85,7 +84,6 @@ class TestJoinRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -112,7 +110,6 @@ class TestJoinRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -135,7 +132,6 @@ class TestJoinRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_project_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_project_relation.py
@@ -57,7 +57,6 @@ class TestProjectRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -81,7 +80,6 @@ class TestProjectRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -108,7 +106,6 @@ class TestProjectRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -131,7 +128,6 @@ class TestProjectRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_read_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_read_relation.py
@@ -40,7 +40,6 @@ class TestReadRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -63,7 +62,6 @@ class TestReadRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -90,7 +88,6 @@ class TestReadRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -113,7 +110,6 @@ class TestReadRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_set_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_set_relation.py
@@ -40,7 +40,6 @@ class TestSetRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -63,7 +62,6 @@ class TestSetRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -90,7 +88,6 @@ class TestSetRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -113,7 +110,6 @@ class TestSetRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_sort_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_sort_relation.py
@@ -40,7 +40,6 @@ class TestSortRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -63,7 +62,6 @@ class TestSortRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -90,7 +88,6 @@ class TestSortRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -113,7 +110,6 @@ class TestSortRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
         )

--- a/substrait_consumer/tests/functional/relations/test_write_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_write_relation.py
@@ -43,7 +43,6 @@ class TestWriteRelation:
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("install substrait")
         cls.db_connection.execute("load substrait")
-        cls.created_tables = set()
 
         yield
 
@@ -67,7 +66,6 @@ class TestWriteRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,
@@ -94,7 +92,6 @@ class TestWriteRelation:
             test_name,
             snapshot,
             self.db_connection,
-            self.created_tables,
             file_names,
             sql_query,
             ibis_expr,

--- a/substrait_consumer/tests/integration/test_acero_tpch.py
+++ b/substrait_consumer/tests/integration/test_acero_tpch.py
@@ -29,7 +29,6 @@ class TestAceroConsumer:
         cls.duckdb_consumer = DuckDBConsumer(cls.db_connection)
         cls.acero_consumer = AceroConsumer()
         cls.utils = SubstraitUtils()
-        cls.created_tables = set()
 
         yield
 
@@ -69,7 +68,7 @@ class TestAceroConsumer:
         # Format the substrait query to include the parquet file paths.
         # Calculate the result of running the substrait query plan.
         consumer = AceroConsumer()
-        consumer.setup(self.db_connection, self.created_tables, file_names)
+        consumer.setup(self.db_connection, file_names)
 
         subtrait_query_result_tb = consumer.run_substrait_query(
             substrait_query
@@ -140,7 +139,7 @@ class TestAceroConsumer:
         """
         # Load the parquet files into DuckDB and return all the table names as a list
         table_names = self.duckdb_consumer.load_tables_from_parquet(
-            self.created_tables, file_names
+            file_names
         )
 
         # Format the sql query by inserting all the table names

--- a/substrait_consumer/tests/integration/test_duckdb_tpch.py
+++ b/substrait_consumer/tests/integration/test_duckdb_tpch.py
@@ -22,7 +22,6 @@ class TestDuckDBConsumer:
         cls.db_connection.execute("INSTALL substrait")
         cls.db_connection.execute("LOAD substrait")
         cls.consumer = DuckDBConsumer(cls.db_connection)
-        cls.created_tables = set()
 
         yield
 
@@ -56,7 +55,7 @@ class TestDuckDBConsumer:
 
         # Load the parquet files into DuckDB and return all the table names as a list
         table_names = self.consumer.load_tables_from_parquet(
-            self.created_tables, file_names
+            file_names
         )
 
         # Format the sql query by inserting all the table names

--- a/substrait_consumer/tests/integration/test_tpch_plans_valid.py
+++ b/substrait_consumer/tests/integration/test_tpch_plans_valid.py
@@ -27,7 +27,6 @@ class TestTpchPlansValid:
         cls.db_connection.execute("INSTALL substrait")
         cls.db_connection.execute("LOAD substrait")
         cls.duckdb_consumer = DuckDBConsumer(cls.db_connection)
-        cls.created_tables = set()
 
         yield
 
@@ -48,7 +47,7 @@ class TestTpchPlansValid:
         """
         producer = IsthmusProducer()
         producer.set_db_connection(self.db_connection)
-        sql_query = producer.format_sql(self.created_tables, sql_query, file_names)
+        sql_query = producer.format_sql(sql_query, file_names)
         substrait_query = producer.produce_substrait(sql_query)
 
         snapshot.snapshot_dir = PLAN_SNAPSHOT_DIR
@@ -115,7 +114,7 @@ class TestTpchPlansValid:
 
         # Load the parquet files into DuckDB and return all the table names as a list
         table_names = self.duckdb_consumer.load_tables_from_parquet(
-            self.created_tables, file_names
+            file_names
         )
 
         # Format the sql query by inserting all the table names


### PR DESCRIPTION
As raised in #122, the current usage of the table creation mechanism is broken because of wrong book keeping of which tables have been created. This has previously been implemented with a set `created_tables` than was handed around different places that used or created tables. The wrong book keeping lead to tables not existing when test queries would run or tables already existing when they should be created.

This PR gets rid of the `created_tables` set all together. Instead, those places responsible for creating tables is expected to do its own book keeping in order to find out which tables need to be created (and all already do that book keeping). This PR implements this logic currently in such a way that existing tables with the same name as those that should be created are first dropped and then recreated. It is conceivable to be more optimistic and not do anything if the table already exists; however, that mechanism breaks if two different tables are loaded with the same name and is thus more brittle.

The PR also fixes `test_substrait_function_names.py`, which used an additional DuckDB connection to prepare the Substrait plan used for test but did not load the tables used in the plans. The PR thus adds the logic to load those tables.

I have compared the list of failing tests before and after this change: no test newly fails and 15 previously failing tests now pass. However, there is a much larger number of tests affected; they now just fail because the corresponding system under test fails rather than because the test harness is broken.

This resolves #112.