### PR TITLE
ci: set up GH action that enforces black formatting on changed lines

### DIFF
--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -1,0 +1,21 @@
+name: Python Formatting
+
+on: [push, pull_request]
+
+jobs:
+  darker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          cache: 'pip'
+      - name: Install darker
+        run: pip install darker
+      - name: Run darker
+        run: |
+          darker --revision origin/main . --diff --check || (echo "Formatting of changed lines does not respect 'black'. Please run 'darker --revision origin/main .' and commit the changes."; false)


### PR DESCRIPTION
This is achieved via the Python package `darker`, which checks that all changed lines are formatted with "black" style. The intent is to strike a balance between enforcing a style but not doing one large commit that only reformats everything, which messes up git history. After this CI rule has run for some time, the (hopefully small) remaining part of the code can still be reformatted with black in one commit and black be enforced from that moment of time.

I have done a quick comparison of various formatters and black seems to be the one that results in a formatting that is closest to the current format, so enforcing that in CI seems like the best choice.

Please see this PR as a means to start a discussion. I believe that enforcing a style in CI is a good way to improve readability without introducing a lot of friction in the normal developer flow. I have no preference for any particular format; what I believe is important that (1) it can run during CI and (2) it can format files easily in the most common editors and/or the command line. Being applicable to diffs is a plus due to the possibility of gradual integration if that is desired. Black/darker fulfills these requirements but I'd be happy to change it for any other of the common formatters.