### PR TITLE
fix: make DB connection a function-scope fixture

### DIFF
--- a/substrait_consumer/tests/adhoc/test_adhoc_expression.py
+++ b/substrait_consumer/tests/adhoc/test_adhoc_expression.py
@@ -32,7 +32,7 @@ class TestAdhocExpression:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
         cls.produced_plans = set()
 

--- a/substrait_consumer/tests/adhoc/test_adhoc_expression.py
+++ b/substrait_consumer/tests/adhoc/test_adhoc_expression.py
@@ -31,13 +31,13 @@ class TestAdhocExpression:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
         cls.produced_plans = set()
 
     @staticmethod
-    @pytest.fixture(scope="function", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_function(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
@@ -37,7 +37,7 @@ class TestApproximationFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
@@ -38,7 +38,7 @@ class TestApproximationFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
@@ -46,7 +46,7 @@ class TestArithmeticDecimalFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
@@ -47,7 +47,7 @@ class TestArithmeticDecimalFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_functions.py
@@ -58,7 +58,7 @@ class TestArithmeticFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_functions.py
@@ -59,7 +59,7 @@ class TestArithmeticFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
@@ -34,7 +34,7 @@ class TestBooleanFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
@@ -33,7 +33,7 @@ class TestBooleanFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
@@ -49,7 +49,7 @@ class TestComparisonFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
@@ -50,7 +50,7 @@ class TestComparisonFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
@@ -48,7 +48,7 @@ class TestDatetimeFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
@@ -47,7 +47,7 @@ class TestDatetimeFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
@@ -51,7 +51,7 @@ class TestLogarithmicFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
@@ -50,7 +50,7 @@ class TestLogarithmicFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
@@ -36,7 +36,7 @@ class TestRoundingFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
@@ -35,7 +35,7 @@ class TestRoundingFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_string_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_string_functions.py
@@ -46,7 +46,7 @@ class TestStringFunctions:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/extension_functions/test_string_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_string_functions.py
@@ -47,7 +47,7 @@ class TestStringFunctions:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/extension_functions/test_substrait_function_names.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_substrait_function_names.py
@@ -20,7 +20,7 @@ class TestSubstraitFunctionNames:
     """
 
     @staticmethod
-    @pytest.fixture(scope="function", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_function(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
@@ -34,7 +34,7 @@ class TestAggregatetRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
@@ -33,7 +33,7 @@ class TestAggregatetRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_ddl_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_ddl_relation.py
@@ -39,7 +39,7 @@ class TestDDLRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_ddl_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_ddl_relation.py
@@ -38,7 +38,7 @@ class TestDDLRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_fetch_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_fetch_relation.py
@@ -33,7 +33,7 @@ class TestFetchRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_fetch_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_fetch_relation.py
@@ -34,7 +34,7 @@ class TestFetchRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_filter_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_filter_relation.py
@@ -37,7 +37,7 @@ class TestfilterRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_filter_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_filter_relation.py
@@ -36,7 +36,7 @@ class TestfilterRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_join_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_join_relation.py
@@ -54,7 +54,7 @@ class TestJoinRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_join_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_join_relation.py
@@ -55,7 +55,7 @@ class TestJoinRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_project_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_project_relation.py
@@ -51,7 +51,7 @@ class TestProjectRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_project_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_project_relation.py
@@ -50,7 +50,7 @@ class TestProjectRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_read_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_read_relation.py
@@ -34,7 +34,7 @@ class TestReadRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_read_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_read_relation.py
@@ -33,7 +33,7 @@ class TestReadRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_set_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_set_relation.py
@@ -34,7 +34,7 @@ class TestSetRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_set_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_set_relation.py
@@ -33,7 +33,7 @@ class TestSetRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_sort_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_sort_relation.py
@@ -34,7 +34,7 @@ class TestSortRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_sort_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_sort_relation.py
@@ -33,7 +33,7 @@ class TestSortRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/functional/relations/test_write_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_write_relation.py
@@ -37,7 +37,7 @@ class TestWriteRelation:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/functional/relations/test_write_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_write_relation.py
@@ -36,7 +36,7 @@ class TestWriteRelation:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/integration/test_acero_tpch.py
+++ b/substrait_consumer/tests/integration/test_acero_tpch.py
@@ -19,7 +19,7 @@ class TestAceroConsumer:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/integration/test_acero_tpch.py
+++ b/substrait_consumer/tests/integration/test_acero_tpch.py
@@ -20,7 +20,7 @@ class TestAceroConsumer:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("INSTALL substrait")

--- a/substrait_consumer/tests/integration/test_duckdb_tpch.py
+++ b/substrait_consumer/tests/integration/test_duckdb_tpch.py
@@ -15,7 +15,7 @@ class TestDuckDBConsumer:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
 

--- a/substrait_consumer/tests/integration/test_duckdb_tpch.py
+++ b/substrait_consumer/tests/integration/test_duckdb_tpch.py
@@ -16,7 +16,7 @@ class TestDuckDBConsumer:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
 
         cls.db_connection = duckdb.connect()

--- a/substrait_consumer/tests/integration/test_tpch_plans_valid.py
+++ b/substrait_consumer/tests/integration/test_tpch_plans_valid.py
@@ -22,7 +22,7 @@ class TestTpchPlansValid:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def setup_teardown_class(request):
+    def setup_teardown_function(request):
         cls = request.cls
         cls.db_connection = duckdb.connect()
         cls.db_connection.execute("INSTALL substrait")

--- a/substrait_consumer/tests/integration/test_tpch_plans_valid.py
+++ b/substrait_consumer/tests/integration/test_tpch_plans_valid.py
@@ -21,7 +21,7 @@ class TestTpchPlansValid:
     """
 
     @staticmethod
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown_class(request):
         cls = request.cls
         cls.db_connection = duckdb.connect()


### PR DESCRIPTION
Many tests use a DuckDB connection as a fixture. That fixture was set to a `class` scope, such that a DuckDB connection was created only once for all tests of a particular class, presumably to speed up tests. However, tests may corrupt the DuckDB instance, making all subsequent tests fail as a result. This lack of reproducibility undermines tests and is far worse than slightly longer-running tests. This PR thus makes all mentioned fixtures function-scoped (by removing the `scope` definition, `function` scope is the default).