### PR TITLE
ci: run all matrix jobs to the end even if others fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
     name: Run consumer tests
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         consumer: [datafusion, duckdb]
     steps:
@@ -35,6 +36,7 @@ jobs:
     name: Run producer tests
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         producer: [datafusion, duckdb, ibis, isthmus]
     steps:


### PR DESCRIPTION
PR #132 changed the definition of Github CI workflows to use the `matrix` feature. If not changed explicitly, the different variants in the matrix are cancelled as soon as the first variant fails. This currently prevents us from knowing which of the systems pass CI. This PR thus sets `fail-fast: false` in order to let all variants in the matrix to run to completion.