### PR TITLE
fix: use `FROM VALUES` in `VirtualTable` producer tests

### DIFF
--- a/substrait_consumer/functional/queries/sql/relations/read_relations.py
+++ b/substrait_consumer/functional/queries/sql/relations/read_relations.py
@@ -17,13 +17,13 @@ READ_RELATIONS = {
     ),
     "datafusion_read_virtual_table": (
         """
-        CREATE TABLE IF NOT EXISTS valuetable AS VALUES(1,'HELLO'),(12,'DATAFUSION');
+        SELECT * FROM VALUES (10)
         """,
         [DataFusionProducer],
     ),
     "duckdb_read_virtual_table": (
         """
-        CREATE TABLE IF NOT EXISTS t1 (i INTEGER, j INTEGER);
+        SELECT * FROM (VALUES (10))
         """,
         [DuckDBProducer],
     ),


### PR DESCRIPTION
The previous producer tests for the `VirtualTable` case of `ReadRel`s for DataFusion and DuckDB used SQL constructs using `CREATE TABLE`. This is problematic because those aren't queries -- they don't return results. This PR uses the `SELECT * FROM VALUES` construct that both systems support in one variant or the other. Unfortunately, both systems still don't pass the test: (1) DuckDB has only added support for `FROM VALUES` to their Substrait extension two weeks ago and (2) DataFusion produces a plan that the validator rejects.