### PR TITLE
feat: improve how producer/consumer names are handled

### DIFF
--- a/substrait_consumer/conftest.py
+++ b/substrait_consumer/conftest.py
@@ -90,15 +90,11 @@ def saveplan(request):
 
 
 PRODUCERS = {
-    "datafusion": DataFusionProducer,
-    "duckdb": DuckDBProducer,
-    "ibis": IbisProducer,
-    "isthmus": IsthmusProducer,
+    cls.name(): cls
+    for cls in [DataFusionProducer, DuckDBProducer, IbisProducer, IsthmusProducer]
 }
 CONSUMERS = {
-    "acero": AceroConsumer,
-    "datafusion": DataFusionConsumer,
-    "duckdb": DuckDBConsumer,
+    cls.name(): cls for cls in [AceroConsumer, DataFusionConsumer, DuckDBConsumer]
 }
 
 

--- a/substrait_consumer/consumers/acero_consumer.py
+++ b/substrait_consumer/consumers/acero_consumer.py
@@ -12,6 +12,10 @@ class AceroConsumer(Consumer):
     Adapts the Acero Substrait consumer to the test framework.
     """
 
+    @classmethod
+    def name(self):
+        return "acero"
+
     def __init__(self):
         self.named_tables = {}
         self.table_provider = lambda names, schema: self.named_tables[names[0].lower()]

--- a/substrait_consumer/consumers/consumer.py
+++ b/substrait_consumer/consumers/consumer.py
@@ -37,6 +37,11 @@ COLUMN_D = [
 
 class Consumer(ABC):
 
+    @classmethod
+    @abstractmethod
+    def name(cls):
+        pass
+
     def setup(
         self, db_connection, local_files: dict[str, str], named_tables: dict[str, str]
     ):

--- a/substrait_consumer/consumers/datafusion_consumer.py
+++ b/substrait_consumer/consumers/datafusion_consumer.py
@@ -16,6 +16,10 @@ class DataFusionConsumer(Consumer):
     Adapts the Datafusion Substrait consumer to the test framework.
     """
 
+    @classmethod
+    def name(self):
+        return "datafusion"
+
     def __init__(self):
         self._ctx = SessionContext()
 

--- a/substrait_consumer/consumers/duckdb_consumer.py
+++ b/substrait_consumer/consumers/duckdb_consumer.py
@@ -12,6 +12,10 @@ class DuckDBConsumer(Consumer):
     Adapts the DuckDB Substrait consumer to the test framework.
     """
 
+    @classmethod
+    def name(self):
+        return "duckdb"
+
     def __init__(self, db_connection=None):
         if db_connection is not None:
             self.db_connection = db_connection

--- a/substrait_consumer/producers/datafusion_producer.py
+++ b/substrait_consumer/producers/datafusion_producer.py
@@ -15,6 +15,11 @@ class DataFusionProducer(Producer):
     """
     Adapts the DataFusion Substrait producer to the test framework.
     """
+
+    @classmethod
+    def name(self):
+        return "datafusion"
+
     def __init__(self, db_connection=None):
         self._ctx = SessionContext()
         if db_connection is not None:
@@ -89,6 +94,3 @@ class DataFusionProducer(Producer):
                     names=["a", "b", "c", "d"],
                 )
                 self._ctx.register_record_batches("t", [[named_tables]])
-
-    def name(self):
-        return "DataFusionProducer"

--- a/substrait_consumer/producers/duckdb_producer.py
+++ b/substrait_consumer/producers/duckdb_producer.py
@@ -12,6 +12,10 @@ class DuckDBProducer(Producer):
     Adapts the DuckDB Substrait producer to the test framework.
     """
 
+    @classmethod
+    def name(self):
+        return "duckdb"
+
     def __init__(self, db_connection=None):
         if db_connection is not None:
             self._db_connection = db_connection
@@ -58,6 +62,3 @@ class DuckDBProducer(Producer):
         result = self._db_connection.query(f"{sql_query}")
         if result is not None:
             return result.arrow()
-
-    def name(self):
-        return "DuckDBProducer"

--- a/substrait_consumer/producers/ibis_producer.py
+++ b/substrait_consumer/producers/ibis_producer.py
@@ -12,6 +12,11 @@ class IbisProducer(Producer):
     """
     Adapts the Ibis Substrait producer to the test framework.
     """
+
+    @classmethod
+    def name(self):
+        return "ibis"
+
     def __init__(self, db_connection=None):
         if db_connection is not None:
             self._db_connection = db_connection
@@ -46,6 +51,3 @@ class IbisProducer(Producer):
         tpch_proto_bytes = compiler.compile(ibis_expr)
         substrait_plan = json_format.MessageToJson(tpch_proto_bytes)
         return substrait_plan
-
-    def name(self):
-        return "IbisProducer"

--- a/substrait_consumer/producers/isthmus_producer.py
+++ b/substrait_consumer/producers/isthmus_producer.py
@@ -11,6 +11,11 @@ class IsthmusProducer(Producer):
     """
     Adapts the Isthmus Substrait producer to the test framework.
     """
+
+    @classmethod
+    def name(self):
+        return "isthmus"
+
     def __init__(self, db_connection=None):
         if db_connection is not None:
             self._db_connection = db_connection
@@ -51,6 +56,3 @@ class IsthmusProducer(Producer):
     def _format_sql(self, sql_query):
         sql_query = re.sub(r"'(\{[0-9a-zA-Z_]+\})'", r"\1", sql_query)
         return sql_query.replace("'t'", "t")
-
-    def name(self):
-        return "IsthmusProducer"

--- a/substrait_consumer/producers/producer.py
+++ b/substrait_consumer/producers/producer.py
@@ -7,6 +7,11 @@ from substrait_consumer.common import SubstraitUtils
 
 
 class Producer(ABC):
+    @classmethod
+    @abstractmethod
+    def name(cls):
+        pass
+
     def __init__(
         self,
         db_connection: Optional[DuckDBPyConnection] = None,

--- a/substrait_consumer/tests/adhoc/test_adhoc_expression.py
+++ b/substrait_consumer/tests/adhoc/test_adhoc_expression.py
@@ -89,7 +89,7 @@ class TestAdhocExpression:
                     outfile.write(json.dumps(python_json, indent=4))
             else:
                 pytest.skip(
-                    f"Plan already produced using the producer: {producer_name}"
+                    f"Plan already produced using the producer: {adhoc_producer.name()}"
                 )
 
         actual_result = consumer.run_substrait_query(substrait_plan)

--- a/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
@@ -9,6 +9,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results, substrait_consumer_sql_test,
     substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -17,14 +21,16 @@ def mark_consumer_tests_as_xfail(request):
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
     func_name = request.node.callspec.id.split('-')[-1]
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-        elif func_name == "approx_percentile":
-            pytest.skip(reason='Catalog Error: Scalar Function with name approx_distinct does not exist!')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
         elif func_name == "approx_distinct":
             pytest.skip(reason='pyarrow.lib.ArrowInvalid: Schema at index 0 was different')
 

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
@@ -10,6 +10,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results, load_custom_duckdb_table,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -17,7 +21,7 @@ def mark_producer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     func_name = request.node.callspec.id.split('-')[1]
-    if producer.__class__.__name__ == 'DataFusionProducer':
+    if isinstance(producer, DataFusionProducer):
         if func_name in ["add", "subtract", "multiply", "divide", "modulus"]:
             pytest.skip(reason='DataFusion error: Invalid function')
 
@@ -28,12 +32,16 @@ def mark_consumer_tests_as_xfail(request):
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
     func_name = request.node.callspec.id.split('-')[-1]
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
         elif func_name in ["min", "max"]:
             pytest.skip(reason='pyarrow.lib.ArrowInvalid: Schema at index 0 was different')
 

--- a/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
@@ -10,6 +10,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results, load_custom_duckdb_table,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -17,12 +21,16 @@ def mark_consumer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
 
 
 @pytest.mark.usefixtures("prepare_tpch_parquet_data")

--- a/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
@@ -9,6 +9,11 @@ from substrait_consumer.functional.common import (
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.functional.comparison_configs import SCALAR_FUNCTIONS
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.producers.isthmus_producer import IsthmusProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -16,13 +21,13 @@ def mark_producer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     func_name = request.node.callspec.id.split('-')[1]
-    if producer.__class__.__name__ == 'DuckDBProducer':
+    if isinstance(producer, DuckDBProducer):
         if func_name == "coalesce":
             pytest.skip(reason='INTERNAL Error: DUMMY_SCAN')
-    elif producer.__class__.__name__ == 'DataFusionProducer':
+    if isinstance(producer, DataFusionProducer):
         if func_name == "coalesce":
             pytest.skip(reason='NotImplemented("Unsupported operator: EmptyRelation"')
-    elif producer.__class__.__name__ == 'IsthmusProducer':
+    if isinstance(producer, IsthmusProducer):
         if func_name == "is_not_distinct_from":
             pytest.skip(reason='java.lang.java.lang.IllegalArgumentException: java.lang.IllegalArgumentException: '
                                'Unable to convert call IS TRUE(boolean?)')
@@ -33,12 +38,16 @@ def mark_consumer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
 
 
 @pytest.mark.usefixtures("prepare_tpch_parquet_data")

--- a/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
@@ -9,6 +9,10 @@ from substrait_consumer.functional.common import (
     substrait_producer_sql_test)
 from substrait_consumer.functional.datetime_configs import SCALAR_FUNCTIONS
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -16,7 +20,7 @@ def mark_producer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     func_name = request.node.callspec.id.split('-')[1]
-    if producer.__class__.__name__ == 'DuckDBProducer':
+    if isinstance(producer, DuckDBProducer):
         if func_name == "add_intervals":
             pytest.skip(reason='INTERNAL Error: DUMMY_SCAN')
 
@@ -27,12 +31,16 @@ def mark_consumer_tests_as_xfail(request):
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
     func_name = request.node.callspec.id.split('-')[-1]
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
         elif func_name in ["extract"]:
             pytest.skip(reason='Results mismatch. Rounding Error')
         elif func_name in ["lt", "lte", "gt", "gte"]:

--- a/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
@@ -9,6 +9,10 @@ from substrait_consumer.functional.common import (
     substrait_producer_sql_test)
 from substrait_consumer.functional.logarithmic_configs import SCALAR_FUNCTIONS
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -16,7 +20,7 @@ def mark_producer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     func_name = request.node.callspec.id.split('-')[1]
-    if producer.__class__.__name__ in ['DuckDBProducer', 'DataFusionProducer']:
+    if isinstance(producer, (DataFusionProducer, DuckDBProducer)):
         if func_name == "logb":
             pytest.skip(reason='Catalog Error: Scalar Function with name logb does not exist!')
 
@@ -26,12 +30,16 @@ def mark_consumer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
 
 
 @pytest.fixture

--- a/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
@@ -9,6 +9,10 @@ from substrait_consumer.functional.common import (
     substrait_producer_sql_test)
 from substrait_consumer.functional.rounding_configs import SCALAR_FUNCTIONS
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -17,12 +21,16 @@ def mark_consumer_tests_as_xfail(request):
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
     func_name = request.node.callspec.id.split('-')[-1]
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
         elif func_name in ["round"]:
             pytest.skip(reason='Results mismatch.')
 

--- a/substrait_consumer/tests/functional/extension_functions/test_substrait_function_names.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_substrait_function_names.py
@@ -10,6 +10,7 @@ from substrait_consumer.functional import (
 from substrait_consumer.functional.common import check_subtrait_function_names, load_custom_duckdb_table
 from substrait_consumer.parametrization import custom_parametrization
 from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.producers.ibis_producer import IbisProducer
 
 
 @pytest.mark.usefixtures("prepare_tpch_parquet_data")
@@ -225,7 +226,7 @@ class TestSubstraitFunctionNames:
 
         # Grab the json representation of the produced substrait plan to verify
         # the proper substrait function name.
-        if type(producer).__name__ == "IbisProducer":
+        if isinstance(producer, IbisProducer):
             if ibis_expr:
                 substrait_plan_json = producer.produce_substrait(
                     sql_query[0], validate=False, ibis_expr=ibis_expr(*args)

--- a/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
@@ -10,7 +10,12 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
-
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.producers.isthmus_producer import IsthmusProducer
+from substrait_consumer.consumers.acero_consumer import AceroConsumer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 @pytest.fixture
 def mark_consumer_tests_as_xfail(request):
@@ -18,19 +23,19 @@ def mark_consumer_tests_as_xfail(request):
     producer = request.getfixturevalue("producer")
     consumer = request.getfixturevalue("consumer")
     test_name = request.getfixturevalue("test_name")
-    if consumer.__class__.__name__ == "DuckDBConsumer":
-        if producer.__class__.__name__ != "DuckDBProducer":
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
             pytest.skip(
-                reason=f"Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}"
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
             )
-    elif consumer.__class__.__name__ == "DataFusionConsumer":
-        if producer.__class__.__name__ != "DataFusionProducer":
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
             pytest.skip(
-                reason=f"Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}"
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
             )
-    elif consumer.__class__.__name__ == "AceroConsumer":
+    elif isinstance(consumer, AceroConsumer):
         if (
-            producer.__class__.__name__ == "IsthmusProducer"
+            not (isinstance(producer, IsthmusProducer))
             and test_name == "compute_within_aggregate"
         ):
             pytest.skip(

--- a/substrait_consumer/tests/functional/relations/test_fetch_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_fetch_relation.py
@@ -10,6 +10,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -17,12 +21,16 @@ def mark_consumer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
 
 
 @pytest.mark.usefixtures("prepare_tpch_parquet_data")

--- a/substrait_consumer/tests/functional/relations/test_filter_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_filter_relation.py
@@ -10,6 +10,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -18,12 +22,17 @@ def mark_consumer_tests_as_xfail(request):
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
     test_case_name = request.node.callspec.id.split('-')[-1]
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
         elif test_case_name in ["having"]:
             pytest.skip(reason='pyarrow.lib.ArrowInvalid: Schema at index 0 was different')
 

--- a/substrait_consumer/tests/functional/relations/test_project_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_project_relation.py
@@ -11,6 +11,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 DATA_DIR = Path(__file__).parent.parent.parent.parent / "data"
@@ -21,7 +25,7 @@ def mark_producer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     test_name = request.node.callspec.id.split('-')[-1]
-    if producer.__class__.__name__ == 'DuckDBProducer':
+    if isinstance(producer, DuckDBProducer):
         if test_name == "distinct_in_project":
             pytest.skip(reason='Not implemented Error: Found unexpected child type in Distinct operator')
 
@@ -32,12 +36,16 @@ def mark_consumer_tests_as_xfail(request):
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
     test_name = request.node.callspec.id.split('-')[-1]
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
         elif test_name == "count_distinct_in_project":
             pytest.skip(reason='pyarrow.lib.ArrowInvalid: Schema at index 0 was different')
 

--- a/substrait_consumer/tests/functional/relations/test_read_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_read_relation.py
@@ -10,6 +10,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -17,12 +21,16 @@ def mark_consumer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
 
 
 @pytest.mark.usefixtures("prepare_small_tpch_parquet_data")

--- a/substrait_consumer/tests/functional/relations/test_set_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_set_relation.py
@@ -10,6 +10,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -17,12 +21,16 @@ def mark_consumer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
 
 
 @pytest.mark.usefixtures("prepare_small_tpch_parquet_data")

--- a/substrait_consumer/tests/functional/relations/test_sort_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_sort_relation.py
@@ -10,6 +10,10 @@ from substrait_consumer.functional.common import (
     generate_snapshot_results,
     substrait_consumer_sql_test, substrait_producer_sql_test)
 from substrait_consumer.parametrization import custom_parametrization
+from substrait_consumer.producers.datafusion_producer import DataFusionProducer
+from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
+from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 
 
 @pytest.fixture
@@ -17,12 +21,16 @@ def mark_consumer_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     producer = request.getfixturevalue('producer')
     consumer = request.getfixturevalue('consumer')
-    if consumer.__class__.__name__ == 'DuckDBConsumer':
-        if producer.__class__.__name__ != 'DuckDBProducer':
-            pytest.skip(reason=f'Unsupported Integration: DuckDBConsumer with non {producer.__class__.__name__}')
-    elif consumer.__class__.__name__ == 'DataFusionConsumer':
-        if producer.__class__.__name__ != 'DataFusionProducer':
-            pytest.skip(reason=f'Unsupported Integration: DataFusionConsumer with non {producer.__class__.__name__}')
+    if isinstance(consumer, DuckDBConsumer):
+        if not isinstance(producer, DuckDBProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: duckdb consumer with {producer.name()} producer"
+            )
+    elif isinstance(consumer, DataFusionConsumer):
+        if not isinstance(producer, DataFusionProducer):
+            pytest.skip(
+                reason=f"Unsupported Integration: datafusion consumer with {producer.name()} producer"
+            )
 
 
 @pytest.mark.usefixtures("prepare_tpch_parquet_data")


### PR DESCRIPTION
This really consists of two semi-independent parts: the PR (1) introduces and abstract class method `name` that is used whenever the name of a producer or consumer is printed (rather than its class name) and it (2) replaces instance tests using string comparison of the name of the class instance with proper `isinstance` tests.