### PR TITLE
fix: bring back correct formulation of skip criterion

### DIFF
--- a/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
@@ -35,9 +35,8 @@ def mark_consumer_tests_as_xfail(request):
             )
     elif isinstance(consumer, AceroConsumer):
         if (
-            not (isinstance(producer, IsthmusProducer))
-            and test_name == "compute_within_aggregate"
-        ):
+            isinstance(producer, IsthmusProducer)
+        ) and test_name == "compute_within_aggregate":
             pytest.skip(
                 reason="'isthmus-acero-compute_within_aggregate' currently crashes"
             )


### PR DESCRIPTION
The recent #147 introduced a bug in a skip criterion that skipped over a test that can lead to a crash by negating a test. This PR brings back the logic.