### PR TITLE
fix: use correct arguments for Ibis' `*trim` expressions

### DIFF
--- a/substrait_consumer/functional/queries/ibis_expressions/string_functions_expr.py
+++ b/substrait_consumer/functional/queries/ibis_expressions/string_functions_expr.py
@@ -78,17 +78,17 @@ def rpad_expr(nation, orders):
 
 
 def ltrim_expr(nation, orders):
-    new_col = nation.n_name.lstrip("A").name("ltrim_N_NAME")
+    new_col = nation.n_name.lstrip().name("ltrim_N_NAME")
     return nation[nation.n_name, new_col]
 
 
 def rtrim_expr(nation, orders):
-    new_col = nation.n_name.rstrip("A").name("rtrim_N_NAME")
+    new_col = nation.n_name.rstrip().name("rtrim_N_NAME")
     return nation[nation.n_name, new_col]
 
 
 def trim_expr(nation, orders):
-    new_col = nation.n_name.strip("A").name("trim_N_NAME")
+    new_col = nation.n_name.strip().name("trim_N_NAME")
     return nation[nation.n_name, new_col]
 
 

--- a/substrait_consumer/tests/functional/extension_functions/string_snapshots/IbisProducer/ltrim-ibis_outcome.txt
+++ b/substrait_consumer/tests/functional/extension_functions/string_snapshots/IbisProducer/ltrim-ibis_outcome.txt
@@ -1,1 +1,1 @@
-<class 'TypeError'>
+<class 'ValueError'>

--- a/substrait_consumer/tests/functional/extension_functions/string_snapshots/IbisProducer/rtrim-ibis_outcome.txt
+++ b/substrait_consumer/tests/functional/extension_functions/string_snapshots/IbisProducer/rtrim-ibis_outcome.txt
@@ -1,1 +1,1 @@
-<class 'TypeError'>
+<class 'ValueError'>

--- a/substrait_consumer/tests/functional/extension_functions/string_snapshots/IbisProducer/trim-ibis_outcome.txt
+++ b/substrait_consumer/tests/functional/extension_functions/string_snapshots/IbisProducer/trim-ibis_outcome.txt
@@ -1,1 +1,1 @@
-<class 'TypeError'>
+<class 'ValueError'>


### PR DESCRIPTION
This PR fixes the usage of Ibis' `*trim` functions, which do not take any arguments but always remove whitespace instead. Unfortunately, this only changes the error that is produced since `*trim` is currently translated to Substrait correctly (see
ibis-project/ibis-substrait#1224).