### PR TITLE
ci: install Isthmus using actions in support matrix workflow

### DIFF
--- a/.github/workflows/support_matrix.yml
+++ b/.github/workflows/support_matrix.yml
@@ -33,11 +33,24 @@ jobs:
       if: ${{ matrix.target == 'produce' }}
       with:
         distribution: 'temurin'
-        java-version: '21'
+        java-version: '17'
 
-    - name: Build and install Isthmus
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
       if: ${{ matrix.target == 'produce' }}
-      run: ./build-and-copy-isthmus-shadow-jar.sh
+      with:
+        gradle-version: 8.8
+
+    - name: Build Isthmus
+      working-directory: ./substrait-java/isthmus
+      if: ${{ matrix.target == 'produce' }}
+      run: ../gradlew shadowJar
+
+    - name: Copy Isthmus JARs
+      if: ${{ matrix.target == 'produce' }}
+      run: |-
+        mkdir ./jars
+        cp substrait-java/isthmus/build/libs/*all.jar ./jars
 
     - name: Run functions tests
       working-directory: ./substrait_consumer/tests/functional/extension_functions


### PR DESCRIPTION
This adopts the same way of building and installing Isthmus and its dependencies in the support matrix workflow as in the test workflow, namely using GH actions. The latter had been updated at some point but not the former. The former also used the wrong version of Java, which now made CI fail. (No idea why it didn't break earlier.)