### PR TITLE
feat: remove test_*.py indirection for producer tests 

### DIFF
--- a/substrait_consumer/conftest.py
+++ b/substrait_consumer/conftest.py
@@ -7,10 +7,24 @@ from filelock import FileLock
 from substrait_consumer.consumers.acero_consumer import AceroConsumer
 from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
 from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
+from substrait_consumer.functional.common import load_custom_duckdb_table
 from substrait_consumer.producers.datafusion_producer import DataFusionProducer
 from substrait_consumer.producers.duckdb_producer import DuckDBProducer
 from substrait_consumer.producers.ibis_producer import IbisProducer
 from substrait_consumer.producers.isthmus_producer import IsthmusProducer
+
+
+@pytest.fixture
+def db_con():
+    db_connection = duckdb.connect()
+    db_connection.execute("INSTALL substrait")
+    db_connection.execute("LOAD substrait")
+
+    load_custom_duckdb_table(db_connection)
+
+    yield db_connection
+
+    db_connection.close()
 
 
 @pytest.fixture(scope="session")

--- a/substrait_consumer/functional/common.py
+++ b/substrait_consumer/functional/common.py
@@ -228,7 +228,7 @@ def substrait_producer_ibis_test(category: str, group: str) -> None:
 
 
 def substrait_producer_sql_test(
-    test_name: str,
+    path: Path,
     snapshot: Snapshot,
     record_property,
     db_con: DuckDBPyConnection,
@@ -271,7 +271,8 @@ def substrait_producer_sql_test(
 
     producer.setup(db_con, local_files, named_tables)
 
-    category, group, name = test_name.split(":")
+    path = str(path).split(".")[0].split("/")
+    category, group, name = path[0], path[1], path[-1]
     record_property("category", category)
     record_property("group", group)
     record_property("name", name)

--- a/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_approximation_functions.py
@@ -3,8 +3,9 @@ import pytest
 
 from substrait_consumer.functional.approximation_configs import AGGREGATE_FUNCTIONS
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, substrait_consumer_sql_test,
-    substrait_producer_sql_test)
+    generate_snapshot_results,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -27,30 +28,6 @@ class TestApproximationFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(AGGREGATE_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_approximation_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:approximation:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(AGGREGATE_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_decimal_functions.py
@@ -4,8 +4,10 @@ import pytest
 from substrait_consumer.functional.arithmetic_decimal_configs import (
     AGGREGATE_FUNCTIONS, SCALAR_FUNCTIONS)
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, load_custom_duckdb_table,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    generate_snapshot_results,
+    load_custom_duckdb_table,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
 
@@ -39,30 +41,6 @@ class TestArithmeticDecimalFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SCALAR_FUNCTIONS + AGGREGATE_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_arithmetic_decimal_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:arithmetic_decimal:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(SCALAR_FUNCTIONS + AGGREGATE_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/extension_functions/test_arithmetic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_arithmetic_functions.py
@@ -4,8 +4,10 @@ import pytest
 from substrait_consumer.functional.arithmetic_configs import (
     AGGREGATE_FUNCTIONS, SCALAR_FUNCTIONS)
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, load_custom_duckdb_table,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    generate_snapshot_results,
+    load_custom_duckdb_table,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
 
@@ -44,30 +46,6 @@ class TestArithmeticFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SCALAR_FUNCTIONS + AGGREGATE_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_arithmetic_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:arithmetic:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(SCALAR_FUNCTIONS + AGGREGATE_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py
@@ -4,8 +4,10 @@ import pytest
 from substrait_consumer.functional.boolean_configs import (
     AGGREGATE_FUNCTIONS, SCALAR_FUNCTIONS)
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, load_custom_duckdb_table,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    generate_snapshot_results,
+    load_custom_duckdb_table,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -29,30 +31,6 @@ class TestBooleanFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SCALAR_FUNCTIONS + AGGREGATE_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_boolean_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:boolean:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(SCALAR_FUNCTIONS + AGGREGATE_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_comparison_functions.py
@@ -2,8 +2,10 @@ import duckdb
 import pytest
 
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, load_custom_duckdb_table,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    generate_snapshot_results,
+    load_custom_duckdb_table,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.functional.comparison_configs import SCALAR_FUNCTIONS
 from substrait_consumer.parametrization import custom_parametrization
 
@@ -28,30 +30,6 @@ class TestComparisonFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SCALAR_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_comparison_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:comparison:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(SCALAR_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_datetime_functions.py
@@ -2,8 +2,9 @@ import duckdb
 import pytest
 
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, substrait_consumer_sql_test,
-    substrait_producer_sql_test)
+    generate_snapshot_results,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.functional.datetime_configs import SCALAR_FUNCTIONS
 from substrait_consumer.parametrization import custom_parametrization
 from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
@@ -43,30 +44,6 @@ class TestDatetimeFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SCALAR_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_datetime_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:datetime:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(SCALAR_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_logarithmic_functions.py
@@ -2,8 +2,9 @@ import duckdb
 import pytest
 
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, substrait_consumer_sql_test,
-    substrait_producer_sql_test)
+    generate_snapshot_results,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.functional.logarithmic_configs import SCALAR_FUNCTIONS
 from substrait_consumer.parametrization import custom_parametrization
 
@@ -27,30 +28,6 @@ class TestLogarithmicFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SCALAR_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_logarithmic_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:logarithmic:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(SCALAR_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_rounding_functions.py
@@ -2,8 +2,9 @@ import duckdb
 import pytest
 
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, substrait_consumer_sql_test,
-    substrait_producer_sql_test)
+    generate_snapshot_results,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.functional.rounding_configs import SCALAR_FUNCTIONS
 from substrait_consumer.parametrization import custom_parametrization
 from substrait_consumer.consumers.datafusion_consumer import DataFusionConsumer
@@ -37,30 +38,6 @@ class TestRoundingFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SCALAR_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_rounding_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:rounding:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(SCALAR_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/extension_functions/test_sql_producers.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_sql_producers.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import duckdb
+import pytest
+from pytest_snapshot.plugin import Snapshot
+
+from substrait_consumer.functional.utils import load_json
+from substrait_consumer.functional.common import substrait_producer_sql_test
+
+CONFIG_DIR = Path(__file__).parent.parent.parent.parent / "functional"
+FUNCTION_CONFIG_DIR = CONFIG_DIR / "function"
+TEST_CASE_PATHS = list(
+    (path.relative_to(CONFIG_DIR),) for path in FUNCTION_CONFIG_DIR.rglob("*.json")
+)
+IDS = (str(path[0]).removesuffix(".json") for path in TEST_CASE_PATHS)
+
+
+@pytest.mark.parametrize(["path"], TEST_CASE_PATHS, ids=IDS)
+@pytest.mark.usefixtures("prepare_tpch_parquet_data")
+@pytest.mark.usefixtures("prepare_small_tpch_parquet_data")
+@pytest.mark.produce_substrait_snapshot
+def test_sql_producer(
+    path: Path,
+    snapshot: Snapshot,
+    record_property,
+    db_con: duckdb.DuckDBPyConnection,
+    producer,
+):
+    test_case = load_json(CONFIG_DIR / path)
+    local_files = test_case["local_files"]
+    named_tables = test_case["named_tables"]
+    sql_query = test_case["sql_query"]
+    substrait_producer_sql_test(
+        path,
+        snapshot,
+        record_property,
+        db_con,
+        local_files,
+        named_tables,
+        sql_query,
+        producer,
+        validate=False,
+    )

--- a/substrait_consumer/tests/functional/extension_functions/test_string_functions.py
+++ b/substrait_consumer/tests/functional/extension_functions/test_string_functions.py
@@ -2,8 +2,9 @@ import duckdb
 import pytest
 
 from substrait_consumer.functional.common import (
-    generate_snapshot_results, substrait_consumer_sql_test,
-    substrait_producer_sql_test)
+    generate_snapshot_results,
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.functional.string_configs import (
     AGGREGATE_FUNCTIONS, SCALAR_FUNCTIONS)
 from substrait_consumer.parametrization import custom_parametrization
@@ -28,30 +29,6 @@ class TestStringFunctions:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SCALAR_FUNCTIONS + AGGREGATE_FUNCTIONS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_string_functions(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"function:string:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-        )
 
     @custom_parametrization(SCALAR_FUNCTIONS + AGGREGATE_FUNCTIONS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_aggregate_relation.py
@@ -5,7 +5,8 @@ from substrait_consumer.functional.aggregate_relation_configs import (
     AGGREGATE_RELATION_TESTS)
 from substrait_consumer.functional.common import (
     generate_snapshot_results,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 from substrait_consumer.producers.isthmus_producer import IsthmusProducer
 from substrait_consumer.consumers.acero_consumer import AceroConsumer
@@ -44,31 +45,6 @@ class TestAggregatetRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(AGGREGATE_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_aggregate_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:aggregate:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(AGGREGATE_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_ddl_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_ddl_relation.py
@@ -1,10 +1,8 @@
 import duckdb
 import pytest
 
-from substrait_consumer.functional.ddl_relation_configs import (
-    DDL_RELATION_TESTS)
-from substrait_consumer.functional.common import (
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+from substrait_consumer.functional.ddl_relation_configs import DDL_RELATION_TESTS
+from substrait_consumer.functional.common import substrait_consumer_sql_test
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -27,31 +25,6 @@ class TestDDLRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(DDL_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_ddl_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:ddl:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(DDL_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_fetch_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_fetch_relation.py
@@ -5,7 +5,8 @@ from substrait_consumer.functional.fetch_relation_configs import (
     FETCH_RELATION_TESTS)
 from substrait_consumer.functional.common import (
     generate_snapshot_results,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -28,31 +29,6 @@ class TestFetchRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(FETCH_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_fetch_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:fetch:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(FETCH_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_filter_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_filter_relation.py
@@ -5,7 +5,8 @@ from substrait_consumer.functional.filter_relation_configs import (
     FILTER_RELATION_TESTS)
 from substrait_consumer.functional.common import (
     generate_snapshot_results,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -28,31 +29,6 @@ class TestfilterRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(FILTER_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_filter_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:filter:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(FILTER_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_join_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_join_relation.py
@@ -5,7 +5,8 @@ from substrait_consumer.functional.join_relation_configs import (
     JOIN_RELATION_TESTS)
 from substrait_consumer.functional.common import (
     generate_snapshot_results,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -28,31 +29,6 @@ class TestJoinRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(JOIN_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_join_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:join:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(JOIN_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_project_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_project_relation.py
@@ -5,7 +5,8 @@ from substrait_consumer.functional.project_relation_configs import (
     PROJECT_RELATION_TESTS)
 from substrait_consumer.functional.common import (
     generate_snapshot_results,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -28,31 +29,6 @@ class TestProjectRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(PROJECT_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_project_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:project:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(PROJECT_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_read_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_read_relation.py
@@ -5,7 +5,8 @@ from substrait_consumer.functional.read_relation_configs import (
     READ_RELATION_TESTS)
 from substrait_consumer.functional.common import (
     generate_snapshot_results,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -28,31 +29,6 @@ class TestReadRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(READ_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_read_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:read:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(READ_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_set_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_set_relation.py
@@ -5,7 +5,8 @@ from substrait_consumer.functional.set_relation_configs import (
     SET_RELATION_TESTS)
 from substrait_consumer.functional.common import (
     generate_snapshot_results,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -28,31 +29,6 @@ class TestSetRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SET_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_set_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:set:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(SET_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_sort_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_sort_relation.py
@@ -5,7 +5,8 @@ from substrait_consumer.functional.sort_relation_configs import (
     SORT_RELATION_TESTS)
 from substrait_consumer.functional.common import (
     generate_snapshot_results,
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+    substrait_consumer_sql_test,
+)
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -28,31 +29,6 @@ class TestSortRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(SORT_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_sort_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:sort:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(SORT_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot

--- a/substrait_consumer/tests/functional/relations/test_sql_producers.py
+++ b/substrait_consumer/tests/functional/relations/test_sql_producers.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import duckdb
+import pytest
+from pytest_snapshot.plugin import Snapshot
+
+from substrait_consumer.functional.utils import load_json
+from substrait_consumer.functional.common import substrait_producer_sql_test
+
+CONFIG_DIR = Path(__file__).parent.parent.parent.parent / "functional"
+RELATION_CONFIG_DIR = CONFIG_DIR / "relation"
+TEST_CASE_PATHS = list(
+    (path.relative_to(CONFIG_DIR),) for path in RELATION_CONFIG_DIR.rglob("*.json")
+)
+IDS = (str(path[0]).removesuffix(".json") for path in TEST_CASE_PATHS)
+
+
+@pytest.mark.parametrize(["path"], TEST_CASE_PATHS, ids=IDS)
+@pytest.mark.usefixtures("prepare_tpch_parquet_data")
+@pytest.mark.usefixtures("prepare_small_tpch_parquet_data")
+@pytest.mark.produce_substrait_snapshot
+def test_sql_producer(
+    path: Path,
+    snapshot: Snapshot,
+    record_property,
+    db_con: duckdb.DuckDBPyConnection,
+    producer,
+):
+    test_case = load_json(CONFIG_DIR / path)
+    local_files = test_case["local_files"]
+    named_tables = test_case["named_tables"]
+    sql_query = test_case["sql_query"]
+    substrait_producer_sql_test(
+        path,
+        snapshot,
+        record_property,
+        db_con,
+        local_files,
+        named_tables,
+        sql_query,
+        producer,
+        validate=True,
+    )

--- a/substrait_consumer/tests/functional/relations/test_write_relation.py
+++ b/substrait_consumer/tests/functional/relations/test_write_relation.py
@@ -1,10 +1,8 @@
 import duckdb
 import pytest
 
-from substrait_consumer.functional.write_relation_configs import (
-    WRITE_RELATION_TESTS)
-from substrait_consumer.functional.common import (
-    substrait_consumer_sql_test, substrait_producer_sql_test)
+from substrait_consumer.functional.write_relation_configs import WRITE_RELATION_TESTS
+from substrait_consumer.functional.common import substrait_consumer_sql_test
 from substrait_consumer.parametrization import custom_parametrization
 
 
@@ -27,31 +25,6 @@ class TestWriteRelation:
         yield
 
         cls.db_connection.close()
-
-    @custom_parametrization(WRITE_RELATION_TESTS)
-    @pytest.mark.produce_substrait_snapshot
-    def test_producer_write_relations(
-        self,
-        snapshot,
-        record_property,
-        test_name: str,
-        local_files: dict[str, str],
-        named_tables: dict[str, str],
-        sql_query: tuple,
-        producer,
-    ) -> None:
-        test_name = f"relation:write:{test_name}"
-        substrait_producer_sql_test(
-            test_name,
-            snapshot,
-            record_property,
-            self.db_connection,
-            local_files,
-            named_tables,
-            sql_query,
-            producer,
-            validate=True
-        )
 
     @custom_parametrization(WRITE_RELATION_TESTS)
     @pytest.mark.consume_substrait_snapshot


### PR DESCRIPTION
This PR is based on and, therefor, includes #156.

This PR removes the indirection through `test_*_functions.py` and `test_*_relation.py` files and uses file globbing on the test definition files for test collection instead. This is the first step in removing the `test_*.py` files alltogether. These files are heavily repetitive while only providing minimum value (adding some metadata and homing some skip definitions, both of which can be done otherwise) and, therefor, a burden for maintainability.
