### PR TITLE
feat: test for outcome in case of success in TPC-H validity tests 

### DIFF
--- a/substrait_consumer/tests/integration/test_tpch_plans_valid.py
+++ b/substrait_consumer/tests/integration/test_tpch_plans_valid.py
@@ -102,6 +102,8 @@ class TestTpchPlansValid:
             snapshot.assert_match(str(type(e)), f"{test_name}_outcome.txt")
             return
 
+        snapshot.assert_match("True", f"{test_name}_outcome.txt")
+
     @custom_parametrization(TPCH_QUERY_TESTS)
     def test_duckdb_substrait_plans_valid(
         self,
@@ -146,3 +148,5 @@ class TestTpchPlansValid:
         except BaseException as e:
             snapshot.assert_match(str(type(e)), f"{test_name}_outcome.txt")
             return
+
+        snapshot.assert_match("True", f"{test_name}_outcome.txt")


### PR DESCRIPTION
~~This PR is based on and, therefor, includes #164.~~

The tests ensuring plan validity only recorded the outcome in case of failure, not in case of success. This means that changing a test case from failure outcome to success outcome *without* updating the snapshots did not lead to CI failure, which is against the intention of the CI architecture. This PR adds snapshot tests also in case of valid plans. This does not currently change any outcomes since none of the TPC-H plans passes the validity test.