### PR TITLE
feat: record outcome of running TPC-H queries in case of success

### DIFF
--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_1/query_01_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_1/query_01_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_10/query_10_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_10/query_10_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_11/query_11_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_11/query_11_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_12/query_12_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_12/query_12_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_13/query_13_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_13/query_13_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_14/query_14_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_14/query_14_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_15/query_15_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_15/query_15_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_18/query_18_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_18/query_18_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_19/query_19_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_19/query_19_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_3/query_03_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_3/query_03_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_5/query_05_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_5/query_05_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_6/query_06_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_6/query_06_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_7/query_07_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_7/query_07_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_8/query_08_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_8/query_08_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_9/query_09_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_tpch/test_substrait_query/test_tpch_sql_9/query_09_outcome.txt
@@ -1,0 +1,1 @@
+{'column_names': True, 'table': True}

--- a/substrait_consumer/tests/integration/test_acero_tpch.py
+++ b/substrait_consumer/tests/integration/test_acero_tpch.py
@@ -10,7 +10,6 @@ from substrait_consumer.common import SubstraitUtils
 from substrait_consumer.consumers.acero_consumer import AceroConsumer
 from substrait_consumer.parametrization import custom_parametrization
 from substrait_consumer.producers.duckdb_producer import DuckDBProducer
-from substrait_consumer.verification import verify_equals
 from substrait_consumer.tests.integration.queries.tpch_test_cases import TPCH_QUERY_TESTS
 
 
@@ -109,20 +108,11 @@ class TestAceroConsumer:
 
         # Verify results between substrait plan query and sql running against
         # duckdb are equal.
-        verify_equals(
-            col_names,
-            exp_col_names,
-            message=f"Actual column names: \n{col_names} \n"
-            f"are not equal to the expected"
-            f"column names: \n{exp_col_names}",
-        )
-        verify_equals(
-            subtrait_query_result_tb,
-            duckdb_query_result_tb,
-            message=f"Result table: \n{subtrait_query_result_tb} \n"
-            f"is not equal to the expected "
-            f"table: \n{duckdb_query_result_tb}",
-        )
+        outcome = {
+            "column_names": col_names == exp_col_names,
+            "table": subtrait_query_result_tb == duckdb_query_result_tb,
+        }
+        snapshot.assert_match(str(outcome), f"query_{tpch_num}_outcome.txt")
 
     @custom_parametrization(TPCH_QUERY_TESTS)
     def test_duckdb_substrait_plan(
@@ -187,20 +177,11 @@ class TestAceroConsumer:
 
         # Verify results between substrait plan query and sql running against
         # duckdb are equal.
-        verify_equals(
-            col_names,
-            exp_col_names,
-            message=f"Actual column names: \n{col_names} \n"
-            f"are not equal to the expected"
-            f"column names: \n{exp_col_names}",
-        )
-        verify_equals(
-            subtrait_query_result_tb,
-            duckdb_sql_result_tb,
-            message=f"Result table: \n{subtrait_query_result_tb} \n"
-            f"is not equal to the expected "
-            f"table: \n{duckdb_sql_result_tb}",
-        )
+        outcome = {
+            "column_names": col_names == exp_col_names,
+            "table": subtrait_query_result_tb == duckdb_sql_result_tb,
+        }
+        snapshot.assert_match(str(outcome), f"query_{tpch_num}_outcome.txt")
 
 
 def arrow_sort_tb_values(table: pa.Table, sortby: Iterable[str]) -> pa.Table:

--- a/substrait_consumer/tests/integration/test_duckdb_tpch.py
+++ b/substrait_consumer/tests/integration/test_duckdb_tpch.py
@@ -6,7 +6,6 @@ from pytest_snapshot.plugin import Snapshot
 from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
 from substrait_consumer.parametrization import custom_parametrization
 from substrait_consumer.producers.duckdb_producer import DuckDBProducer
-from substrait_consumer.verification import verify_equals
 from .queries.tpch_test_cases import TPCH_QUERY_TESTS
 
 
@@ -90,17 +89,8 @@ class TestDuckDBConsumer:
 
         # Verify results between substrait plan query and sql running against
         # duckdb are equal.
-        verify_equals(
-            col_names,
-            exp_col_names,
-            message=f"Actual column names: \n{col_names} \n"
-            f"are not equal to the expected"
-            f"column names: \n{exp_col_names}",
-        )
-        verify_equals(
-            subtrait_query_result_tb,
-            duckdb_sql_result_tb,
-            message=f"Result table: \n{subtrait_query_result_tb} \n"
-            f"is not equal to the expected "
-            f"table: \n{duckdb_sql_result_tb}",
-        )
+        outcome = {
+            "column_names": col_names == exp_col_names,
+            "table": subtrait_query_result_tb == duckdb_sql_result_tb,
+        }
+        snapshot.assert_match(str(outcome), f"query_{tpch_num}_outcome.txt")


### PR DESCRIPTION
~~This PR is based on and, therefor, includes #164.~~

The tests didn't previously record the outcome of running TPC-H queries in terms of success but still used assertions. This didn't show up because all queries where the tests got to the point where they could *run* also produced the correct results. However, this is against the philosophy of the repository, so this PR records also successful outcomes.