### PR TITLE
feat: do TPC-H plan validation for DuckDB with `Producer`

### DIFF
--- a/substrait_consumer/tests/integration/snapshots/test_tpch_plans_valid/test_duckdb_substrait_plans_valid/test_tpch_sql_18/test_tpch_sql_18_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_tpch_plans_valid/test_duckdb_substrait_plans_valid/test_tpch_sql_18/test_tpch_sql_18_outcome.txt
@@ -1,1 +1,1 @@
-<class 'google.protobuf.json_format.ParseError'>
+<class 'ValueError'>


### PR DESCRIPTION
~~This PR is based on and, therefor, includes #168.~~

This PR reuses the plan validation that is part of the `Producer` interface in the tests that check plan validity for the TPC-H queries for DuckDB. This leads to the same result in terms of validity; however, the error class is different in the one error case, so the outcome changes from one error to another for that query.




