### PR TITLE
feat: make TPC-H outcome format coherent with new outcome format

### DIFF
--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_1/query_01_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_1/query_01_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_10/query_10_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_10/query_10_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_11/query_11_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_11/query_11_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_12/query_12_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_12/query_12_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_13/query_13_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_13/query_13_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_14/query_14_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_14/query_14_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_15/query_15_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_15/query_15_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_18/query_18_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_18/query_18_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_19/query_19_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_19/query_19_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_3/query_03_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_3/query_03_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_5/query_05_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_5/query_05_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_6/query_06_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_6/query_06_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_7/query_07_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_7/query_07_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_8/query_08_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_8/query_08_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_9/query_09_outcome.txt
+++ b/substrait_consumer/tests/integration/snapshots/test_duckdb_on_duckdb/test_substrait_query/test_tpch_sql_9/query_09_outcome.txt
@@ -1,1 +1,1 @@
-{'column_names': True, 'table': True}
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/test_duckdb_on_acero.py
+++ b/substrait_consumer/tests/integration/test_duckdb_on_acero.py
@@ -95,7 +95,7 @@ def test_substrait_query(
     # Verify results between substrait plan query and sql running against
     # duckdb are equal.
     outcome = {
-        "column_names": col_names == exp_col_names,
-        "table": subtrait_query_result_tb == duckdb_sql_result_tb,
+        "schema": col_names == exp_col_names,
+        "data": subtrait_query_result_tb == duckdb_sql_result_tb,
     }
     snapshot.assert_match(str(outcome), outcome_path)

--- a/substrait_consumer/tests/integration/test_duckdb_on_duckdb.py
+++ b/substrait_consumer/tests/integration/test_duckdb_on_duckdb.py
@@ -95,7 +95,7 @@ def test_substrait_query(
     # Verify results between substrait plan query and sql running against
     # duckdb are equal.
     outcome = {
-        "column_names": col_names == exp_col_names,
-        "table": subtrait_query_result_tb == duckdb_sql_result_tb,
+        "schema": col_names == exp_col_names,
+        "data": subtrait_query_result_tb == duckdb_sql_result_tb,
     }
     snapshot.assert_match(str(outcome), outcome_path)

--- a/substrait_consumer/tests/integration/test_isthmus_on_acero.py
+++ b/substrait_consumer/tests/integration/test_isthmus_on_acero.py
@@ -99,7 +99,7 @@ def test_isthmus_substrait_plan(
     # Verify results between substrait plan query and sql running against
     # duckdb are equal.
     outcome = {
-        "column_names": col_names == exp_col_names,
-        "table": subtrait_query_result_tb == duckdb_sql_result_tb,
+        "schema": col_names == exp_col_names,
+        "data": subtrait_query_result_tb == duckdb_sql_result_tb,
     }
     snapshot.assert_match(str(outcome), outcome_path)


### PR DESCRIPTION
~~This PR depends on and, therefor, includes #175.~~

This PR makes the format of the outcome snapshot files coherent with the new outcome format introduced in #176 for the remaining tests. More precisely, the name of the dictionary entries change from `column_names` to `schema` and from `table` to `data`.