### PR TITLE
feat: use result snapshot to check TPC-H consumer results

### DIFF
--- a/substrait_consumer/tests/integration/test_duckdb_on_acero.py
+++ b/substrait_consumer/tests/integration/test_duckdb_on_acero.py
@@ -107,18 +107,28 @@ def test_substrait_query(
         proto_bytes = f.read()
 
     try:
-        subtrait_query_result_tb = consumer.run_substrait_query(proto_bytes)
+        consumer_result = consumer.run_substrait_query(proto_bytes)
     except BaseException as e:
         snapshot.assert_match(str(type(e)), outcome_path)
         return
 
-    col_names = [x.lower() for x in subtrait_query_result_tb.column_names]
-    exp_col_names = [x.lower() for x in duckdb_result.column_names]
+    consumer_result = consumer_result.rename_columns(
+        list(map(str.lower, consumer_result.column_names))
+    )
+    str_result_schema = str(consumer_result.schema)
+    consumer_result_data = []
+    for column in consumer_result.columns:
+        consumer_result_data.extend(column.data)
+        consumer_result_data.extend([" "])
+    str_result_data = "\n".join(map(str, consumer_result_data))
+
+    schema_match_result = check_match(snapshot, str_result_schema, schema_path)
+    data_match_result = check_match(snapshot, str_result_data, data_path)
 
     # Verify results between substrait plan query and sql running against
     # duckdb are equal.
     outcome = {
-        "schema": col_names == exp_col_names,
-        "data": subtrait_query_result_tb == duckdb_result,
+        "schema": schema_match_result,
+        "data": data_match_result,
     }
     snapshot.assert_match(str(outcome), outcome_path)

--- a/substrait_consumer/tests/integration/test_duckdb_on_duckdb.py
+++ b/substrait_consumer/tests/integration/test_duckdb_on_duckdb.py
@@ -107,18 +107,28 @@ def test_substrait_query(
         proto_bytes = f.read()
 
     try:
-        subtrait_query_result_tb = consumer.run_substrait_query(proto_bytes)
+        consumer_result = consumer.run_substrait_query(proto_bytes)
     except BaseException as e:
         snapshot.assert_match(str(type(e)), outcome_path)
         return
 
-    col_names = [x.lower() for x in subtrait_query_result_tb.column_names]
-    exp_col_names = [x.lower() for x in duckdb_result.column_names]
+    consumer_result = consumer_result.rename_columns(
+        list(map(str.lower, consumer_result.column_names))
+    )
+    str_result_schema = str(consumer_result.schema)
+    consumer_result_data = []
+    for column in consumer_result.columns:
+        consumer_result_data.extend(column.data)
+        consumer_result_data.extend([" "])
+    str_result_data = "\n".join(map(str, consumer_result_data))
+
+    schema_match_result = check_match(snapshot, str_result_schema, schema_path)
+    data_match_result = check_match(snapshot, str_result_data, data_path)
 
     # Verify results between substrait plan query and sql running against
     # duckdb are equal.
     outcome = {
-        "schema": col_names == exp_col_names,
-        "data": subtrait_query_result_tb == duckdb_result,
+        "schema": schema_match_result,
+        "data": data_match_result,
     }
     snapshot.assert_match(str(outcome), outcome_path)


### PR DESCRIPTION
~~This PR depends on and, therefor, includes #178.~~

This PR uses the result snapshots containing the DuckDB results introduced in #178 in order to check for correctness of the consumers in the TPC-H tests. This is one of the final steps before turning this test into calls to the generic test functions.
