### PR TITLE
feat: factor out DuckDB result generation of TPC-H tests

### DIFF
--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q01-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q01-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q02-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q02-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q03-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q03-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q04-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q04-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q05-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q05-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q06-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q06-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q07-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q07-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q08-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q08-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q09-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q09-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q10-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q10-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q11-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q11-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q12-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q12-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q13-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q13-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q14-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q14-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q15-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q15-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q16-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q16-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q17-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q17-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q18-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q18-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q19-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q19-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q20-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q20-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q21-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q21-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q22-generate-outcome.txt
+++ b/substrait_consumer/tests/functional/integration/tpch_snapshots/integration_test_results/q22-generate-outcome.txt
@@ -1,0 +1,1 @@
+{'schema': True, 'data': True}

--- a/substrait_consumer/tests/integration/test_duckdb_on_acero.py
+++ b/substrait_consumer/tests/integration/test_duckdb_on_acero.py
@@ -70,29 +70,6 @@ def test_substrait_query(
     data_path = f"q{tpch_num:02d}_result_data.txt"
     schema_path = f"q{tpch_num:02d}_result_schema.txt"
 
-    # Calculate results to verify against by running the SQL query on DuckDB
-    try:
-        duckdb_result = producer.run_sql_query(sql_query)
-    except BaseException as e:
-        snapshot.assert_match(str(type(e)), outcome_path)
-        return
-
-    duckdb_result = duckdb_result.rename_columns(
-        list(map(str.lower, duckdb_result.column_names))
-    )
-    str_result_schema = str(duckdb_result.schema)
-    duckdb_result_data = []
-    for column in duckdb_result.columns:
-        duckdb_result_data.extend(column.data)
-        duckdb_result_data.extend([" "])
-    str_result_data = "\n".join(map(str, duckdb_result_data))
-
-    schema_match_result = check_match(snapshot, str_result_schema, schema_path)
-    data_match_result = check_match(snapshot, str_result_data, data_path)
-
-    assert schema_match_result
-    assert data_match_result
-
     # Load DuckDB plan from file.
     substrait_plan_path = (
         PLAN_DIR

--- a/substrait_consumer/tests/integration/test_duckdb_on_duckdb.py
+++ b/substrait_consumer/tests/integration/test_duckdb_on_duckdb.py
@@ -70,29 +70,6 @@ def test_substrait_query(
     data_path = f"q{tpch_num:02d}_result_data.txt"
     schema_path = f"q{tpch_num:02d}_result_schema.txt"
 
-    # Calculate results to verify against by running the SQL query on DuckDB
-    try:
-        duckdb_result = producer.run_sql_query(sql_query)
-    except BaseException as e:
-        snapshot.assert_match(str(type(e)), outcome_path)
-        return
-
-    duckdb_result = duckdb_result.rename_columns(
-        list(map(str.lower, duckdb_result.column_names))
-    )
-    str_result_schema = str(duckdb_result.schema)
-    duckdb_result_data = []
-    for column in duckdb_result.columns:
-        duckdb_result_data.extend(column.data)
-        duckdb_result_data.extend([" "])
-    str_result_data = "\n".join(map(str, duckdb_result_data))
-
-    schema_match_result = check_match(snapshot, str_result_schema, schema_path)
-    data_match_result = check_match(snapshot, str_result_data, data_path)
-
-    assert schema_match_result
-    assert data_match_result
-
     # Load DuckDB plan from file.
     substrait_plan_path = (
         PLAN_DIR

--- a/substrait_consumer/tests/integration/test_isthmus_on_acero.py
+++ b/substrait_consumer/tests/integration/test_isthmus_on_acero.py
@@ -74,29 +74,6 @@ def test_isthmus_substrait_plan(
     data_path = f"q{tpch_num:02d}_result_data.txt"
     schema_path = f"q{tpch_num:02d}_result_schema.txt"
 
-    # Calculate results to verify against by running the SQL query on DuckDB
-    try:
-        consumer_result = producer.run_sql_query(sql_query)
-    except BaseException as e:
-        snapshot.assert_match(str(type(e)), outcome_path)
-        return
-
-    consumer_result = consumer_result.rename_columns(
-        list(map(str.lower, consumer_result.column_names))
-    )
-    str_result_schema = str(consumer_result.schema)
-    consumer_result_data = []
-    for column in consumer_result.columns:
-        consumer_result_data.extend(column.data)
-        consumer_result_data.extend([" "])
-    str_result_data = "\n".join(map(str, consumer_result_data))
-
-    schema_match_result = check_match(snapshot, str_result_schema, schema_path)
-    data_match_result = check_match(snapshot, str_result_data, data_path)
-
-    assert schema_match_result
-    assert data_match_result
-
     # Load Isthmus plan from file.
     substrait_plan_path = (
         PLAN_DIR

--- a/substrait_consumer/tests/integration/test_tpch_plans_valid.py
+++ b/substrait_consumer/tests/integration/test_tpch_plans_valid.py
@@ -4,7 +4,10 @@ import duckdb
 import pytest
 from pytest_snapshot.plugin import Snapshot
 
-from substrait_consumer.functional.common import substrait_producer_sql_test
+from substrait_consumer.functional.common import (
+    substrait_producer_sql_test,
+    generate_snapshot_results,
+)
 from substrait_consumer.functional.utils import load_json
 from substrait_consumer.producers.duckdb_producer import DuckDBProducer
 from substrait_consumer.producers.isthmus_producer import IsthmusProducer
@@ -69,4 +72,27 @@ def test_substrait_plans_valid(
         sql_query,
         producer,
         validate=True,
+    )
+
+
+@pytest.mark.parametrize(["path"], TEST_CASE_PATHS, ids=IDS)
+@pytest.mark.usefixtures("prepare_tpch_parquet_data")
+def test_generate_snapshot_results(
+    path: Path,
+    snapshot: Snapshot,
+    record_property,
+    db_con: duckdb.DuckDBPyConnection,
+):
+    test_case = load_json(CONFIG_DIR / path)
+    local_files = test_case["local_files"]
+    named_tables = test_case["named_tables"]
+    sql_query = test_case["sql_query"]
+    generate_snapshot_results(
+        path,
+        snapshot,
+        record_property,
+        db_con,
+        local_files,
+        named_tables,
+        sql_query,
     )


### PR DESCRIPTION
~~This PR depends on and, therefor, includes #179 and #180.~~

This PR creates a new test target that generates references results for the TPC-H consumer tests using DuckDB as a wrapper to `generate_snapshot_results`. That logic had previously been inlined in the various TPC-H tests. This PR also removes that logic from there; the consumer behaviour is thus now tested only against the snapshots generated by the new targets and does not need any reference result produced by DuckDB on the fly.