### PR TITLE
feat: implement TPC-H consumer tests using generic infra 

### DIFF
--- a/substrait_consumer/tests/integration/test_duckdb_on_acero.py
+++ b/substrait_consumer/tests/integration/test_duckdb_on_acero.py
@@ -5,14 +5,14 @@ import pytest
 from pytest_snapshot.plugin import Snapshot
 
 from substrait_consumer.consumers.acero_consumer import AceroConsumer
-from substrait_consumer.functional.common import check_match
+from substrait_consumer.functional.common import substrait_consumer_sql_test
 from substrait_consumer.functional.utils import load_json
 from substrait_consumer.producers.duckdb_producer import DuckDBProducer
 
 PLAN_DIR = Path(__file__).parent.parent / "functional" / "tpch"
 
-CONFIG_DIR = Path(__file__).parent.parent / "integration"
-TPCH_CONFIG_DIR = CONFIG_DIR / "tpch"
+CONFIG_DIR = Path(__file__).parent.parent
+TPCH_CONFIG_DIR = CONFIG_DIR / "integration" / "tpch"
 TEST_CASE_PATHS = list(
     (path.relative_to(CONFIG_DIR),) for path in TPCH_CONFIG_DIR.rglob("*.json")
 )
@@ -29,83 +29,20 @@ def test_substrait_query(
     path: Path,
     snapshot: Snapshot,
     db_con: duckdb.DuckDBPyConnection,
+    record_property,
 ) -> None:
-    """
-    1.  Load all the parquet files into DuckDB as separate named_tables.
-    2.  Format the SQL query to work with DuckDB by inserting all the table names.
-    3.  Execute the SQL on DuckDB.
-    4.  Run the substrait query plan.
-    5.  Compare substrait query plan results against the results of
-        running the SQL on DuckDB.
-
-    Parameters:
-        test_name:
-            Name of test.
-        local_files:
-            A `dict` mapping format argument names to local files paths.
-        named_tables:
-            A `dict` mapping table names to local file paths.
-        sql_query:
-            SQL query.
-    """
     test_case = load_json(CONFIG_DIR / path)
-    test_name = test_case["test_name"]
     local_files = test_case["local_files"]
     named_tables = test_case["named_tables"]
-    sql_query, supported_producers = test_case["sql_query"]
-
-    assert "duckdb" in supported_producers
-
-    tpch_num = int(test_name.split("_")[-1])
-
-    snapshot.snapshot_dir = TPCH_SNAPSHOT_DIR / "integration_test_results"
-
     consumer = AceroConsumer()
     producer = DuckDBProducer()
-
-    consumer.setup(db_con, local_files, named_tables)
-    producer.setup(db_con, local_files, named_tables)
-
-    outcome_path = f"q{tpch_num:02d}-{producer.name()}-{consumer.name()}_outcome.txt"
-    data_path = f"q{tpch_num:02d}_result_data.txt"
-    schema_path = f"q{tpch_num:02d}_result_schema.txt"
-
-    # Load DuckDB plan from file.
-    substrait_plan_path = (
-        PLAN_DIR
-        / f"q{tpch_num:02d}_snapshots"
-        / type(producer).__name__
-        / f"q{tpch_num:02d}_plan.json"
+    substrait_consumer_sql_test(
+        path,
+        snapshot,
+        record_property,
+        db_con,
+        local_files,
+        named_tables,
+        producer,
+        consumer,
     )
-    if not substrait_plan_path.is_file():
-        pytest.skip(f"No substrait plan exists for {producer.name()}:{test_name}")
-
-    with open(substrait_plan_path, "r") as f:
-        proto_bytes = f.read()
-
-    try:
-        consumer_result = consumer.run_substrait_query(proto_bytes)
-    except BaseException as e:
-        snapshot.assert_match(str(type(e)), outcome_path)
-        return
-
-    consumer_result = consumer_result.rename_columns(
-        list(map(str.lower, consumer_result.column_names))
-    )
-    str_result_schema = str(consumer_result.schema)
-    consumer_result_data = []
-    for column in consumer_result.columns:
-        consumer_result_data.extend(column.data)
-        consumer_result_data.extend([" "])
-    str_result_data = "\n".join(map(str, consumer_result_data))
-
-    schema_match_result = check_match(snapshot, str_result_schema, schema_path)
-    data_match_result = check_match(snapshot, str_result_data, data_path)
-
-    # Verify results between substrait plan query and sql running against
-    # duckdb are equal.
-    outcome = {
-        "schema": schema_match_result,
-        "data": data_match_result,
-    }
-    snapshot.assert_match(str(outcome), outcome_path)

--- a/substrait_consumer/tests/integration/test_duckdb_on_duckdb.py
+++ b/substrait_consumer/tests/integration/test_duckdb_on_duckdb.py
@@ -5,14 +5,14 @@ import pytest
 from pytest_snapshot.plugin import Snapshot
 
 from substrait_consumer.consumers.duckdb_consumer import DuckDBConsumer
-from substrait_consumer.functional.common import check_match
+from substrait_consumer.functional.common import substrait_consumer_sql_test
 from substrait_consumer.functional.utils import load_json
 from substrait_consumer.producers.duckdb_producer import DuckDBProducer
 
 PLAN_DIR = Path(__file__).parent.parent / "functional" / "tpch"
 
-CONFIG_DIR = Path(__file__).parent.parent / "integration"
-TPCH_CONFIG_DIR = CONFIG_DIR / "tpch"
+CONFIG_DIR = Path(__file__).parent.parent
+TPCH_CONFIG_DIR = CONFIG_DIR / "integration" / "tpch"
 TEST_CASE_PATHS = list(
     (path.relative_to(CONFIG_DIR),) for path in TPCH_CONFIG_DIR.rglob("*.json")
 )
@@ -29,83 +29,20 @@ def test_substrait_query(
     path: Path,
     snapshot: Snapshot,
     db_con: duckdb.DuckDBPyConnection,
+    record_property,
 ) -> None:
-    """
-    1.  Load all the parquet files into DuckDB as separate named_tables.
-    2.  Format the SQL query to work with DuckDB by inserting all the table names.
-    3.  Execute the SQL on DuckDB.
-    4.  Run the substrait query plan.
-    5.  Compare substrait query plan results against the results of
-        running the SQL on DuckDB.
-
-    Parameters:
-        test_name:
-            Name of test.
-        local_files:
-            A `dict` mapping format argument names to local files paths.
-        named_tables:
-            A `dict` mapping table names to local file paths.
-        sql_query:
-            SQL query.
-    """
     test_case = load_json(CONFIG_DIR / path)
-    test_name = test_case["test_name"]
     local_files = test_case["local_files"]
     named_tables = test_case["named_tables"]
-    sql_query, supported_producers = test_case["sql_query"]
-
-    assert "duckdb" in supported_producers
-
-    tpch_num = int(test_name.split("_")[-1])
-
-    snapshot.snapshot_dir = TPCH_SNAPSHOT_DIR / "integration_test_results"
-
     consumer = DuckDBConsumer()
     producer = DuckDBProducer()
-
-    consumer.setup(db_con, local_files, named_tables)
-    producer.setup(db_con, local_files, named_tables)
-
-    outcome_path = f"q{tpch_num:02d}-{producer.name()}-{consumer.name()}_outcome.txt"
-    data_path = f"q{tpch_num:02d}_result_data.txt"
-    schema_path = f"q{tpch_num:02d}_result_schema.txt"
-
-    # Load DuckDB plan from file.
-    substrait_plan_path = (
-        PLAN_DIR
-        / f"q{tpch_num:02d}_snapshots"
-        / type(producer).__name__
-        / f"q{tpch_num:02d}_plan.json"
+    substrait_consumer_sql_test(
+        path,
+        snapshot,
+        record_property,
+        db_con,
+        local_files,
+        named_tables,
+        producer,
+        consumer,
     )
-    if not substrait_plan_path.is_file():
-        pytest.skip(f"No substrait plan exists for {producer.name()}:{test_name}")
-
-    with open(substrait_plan_path, "r") as f:
-        proto_bytes = f.read()
-
-    try:
-        consumer_result = consumer.run_substrait_query(proto_bytes)
-    except BaseException as e:
-        snapshot.assert_match(str(type(e)), outcome_path)
-        return
-
-    consumer_result = consumer_result.rename_columns(
-        list(map(str.lower, consumer_result.column_names))
-    )
-    str_result_schema = str(consumer_result.schema)
-    consumer_result_data = []
-    for column in consumer_result.columns:
-        consumer_result_data.extend(column.data)
-        consumer_result_data.extend([" "])
-    str_result_data = "\n".join(map(str, consumer_result_data))
-
-    schema_match_result = check_match(snapshot, str_result_schema, schema_path)
-    data_match_result = check_match(snapshot, str_result_data, data_path)
-
-    # Verify results between substrait plan query and sql running against
-    # duckdb are equal.
-    outcome = {
-        "schema": schema_match_result,
-        "data": data_match_result,
-    }
-    snapshot.assert_match(str(outcome), outcome_path)

--- a/substrait_consumer/tests/integration/test_isthmus_on_acero.py
+++ b/substrait_consumer/tests/integration/test_isthmus_on_acero.py
@@ -5,14 +5,14 @@ import pytest
 from pytest_snapshot.plugin import Snapshot
 
 from substrait_consumer.consumers.acero_consumer import AceroConsumer
-from substrait_consumer.functional.common import check_match
+from substrait_consumer.functional.common import substrait_consumer_sql_test
 from substrait_consumer.functional.utils import load_json
-from substrait_consumer.producers.duckdb_producer import DuckDBProducer
+from substrait_consumer.producers.isthmus_producer import IsthmusProducer
 
 PLAN_DIR = Path(__file__).parent.parent / "functional" / "tpch"
 
-CONFIG_DIR = Path(__file__).parent.parent / "integration"
-TPCH_CONFIG_DIR = CONFIG_DIR / "tpch"
+CONFIG_DIR = Path(__file__).parent.parent
+TPCH_CONFIG_DIR = CONFIG_DIR / "integration" / "tpch"
 TEST_CASE_PATHS = list(
     (path.relative_to(CONFIG_DIR),) for path in TPCH_CONFIG_DIR.rglob("*.json")
 )
@@ -29,87 +29,20 @@ def test_isthmus_substrait_plan(
     path: Path,
     snapshot: Snapshot,
     db_con: duckdb.DuckDBPyConnection,
+    record_property,
 ) -> None:
-    """
-    1.  Format the substrait_query by replacing the 'local_files' 'uri_file'
-        path with the full path to the parquet data.
-    2.  Format the SQL query to work with DuckDB by setting the 'Table'
-        Parameters to be the relative files paths for parquet data.
-    3.  Run the substrait query plan.
-    4.  Execute the SQL on DuckDB.
-    5.  Compare substrait query plan results against the results of
-        running the SQL on DuckDB.
-
-    Parameters:
-        test_name:
-            Name of test.
-        local_files:
-            A `dict` mapping format argument names to local files paths.
-        named_tables:
-            A `dict` mapping table names to local file paths.
-        sql_query:
-            SQL query.
-        substrait_query:
-            Substrait query.
-    """
     test_case = load_json(CONFIG_DIR / path)
-    test_name = test_case["test_name"]
     local_files = test_case["local_files"]
     named_tables = test_case["named_tables"]
-    sql_query, supported_producers = test_case["sql_query"]
-
-    assert "duckdb" in supported_producers
-
-    tpch_num = int(test_name.split("_")[-1])
-
-    snapshot.snapshot_dir = TPCH_SNAPSHOT_DIR / "integration_test_results"
-
     consumer = AceroConsumer()
-    producer = DuckDBProducer()
-
-    consumer.setup(db_con, local_files, named_tables)
-    producer.setup(db_con, local_files, named_tables)
-
-    outcome_path = f"q{tpch_num:02d}-isthmus-{consumer.name()}_outcome.txt"
-    data_path = f"q{tpch_num:02d}_result_data.txt"
-    schema_path = f"q{tpch_num:02d}_result_schema.txt"
-
-    # Load Isthmus plan from file.
-    substrait_plan_path = (
-        PLAN_DIR
-        / f"q{tpch_num:02d}_snapshots"
-        / "IsthmusProducer"
-        / f"q{tpch_num:02d}_plan.json"
+    producer = IsthmusProducer()
+    substrait_consumer_sql_test(
+        path,
+        snapshot,
+        record_property,
+        db_con,
+        local_files,
+        named_tables,
+        producer,
+        consumer,
     )
-    if not substrait_plan_path.is_file():
-        pytest.skip(f"No substrait plan exists for {producer.name()}:{test_name}")
-
-    with open(substrait_plan_path, "r") as f:
-        proto_bytes = f.read()
-
-    try:
-        consumer_result = consumer.run_substrait_query(proto_bytes)
-    except BaseException as e:
-        snapshot.assert_match(str(type(e)), outcome_path)
-        return
-
-    consumer_result = consumer_result.rename_columns(
-        list(map(str.lower, consumer_result.column_names))
-    )
-    str_result_schema = str(consumer_result.schema)
-    consumer_result_data = []
-    for column in consumer_result.columns:
-        consumer_result_data.extend(column.data)
-        consumer_result_data.extend([" "])
-    str_result_data = "\n".join(map(str, consumer_result_data))
-
-    schema_match_result = check_match(snapshot, str_result_schema, schema_path)
-    data_match_result = check_match(snapshot, str_result_data, data_path)
-
-    # Verify results between substrait plan query and sql running against
-    # duckdb are equal.
-    outcome = {
-        "schema": schema_match_result,
-        "data": data_match_result,
-    }
-    snapshot.assert_match(str(outcome), outcome_path)


### PR DESCRIPTION
~~This PR is based on and, therefor, includes #181.~~

This PR implements the TPC-H consumer tests using the generic `substrait_consumer_sql_test` function that the other consumer tests are implemented with. Previous PRs had factored out other test logic from these tests such that they were now equivalent with the generic logic. What remains now from the TPC-H tests is merely glue code, which we can futher merge with the other tests in the next PRs.