### PR TITLE
chore: update `substrait-java` git submodule to next version 

### DIFF
--- a/substrait_consumer/snapshots/producer/integration/tpch/q06-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q06-isthmus_plan.json
@@ -349,20 +349,12 @@
                               }
                             }, {
                               "value": {
-                                "cast": {
-                                  "type": {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  "input": {
-                                    "literal": {
-                                      "i32": 24
-                                    }
-                                  },
-                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                "literal": {
+                                  "decimal": {
+                                    "value": "YAkAAAAAAAAAAAAAAAAAAA==",
+                                    "precision": 15,
+                                    "scale": 2
+                                  }
                                 }
                               }
                             }]

--- a/substrait_consumer/snapshots/producer/integration/tpch/q08-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q08-isthmus_plan.json
@@ -1247,6 +1247,7 @@
                   "functionReference": 8,
                   "outputType": {
                     "decimal": {
+                      "scale": 6,
                       "precision": 19,
                       "nullability": "NULLABILITY_NULLABLE"
                     }

--- a/substrait_consumer/snapshots/producer/integration/tpch/q11-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q11-isthmus_plan.json
@@ -446,83 +446,142 @@
                     }
                   }, {
                     "value": {
-                      "subquery": {
-                        "scalar": {
-                          "input": {
-                            "project": {
-                              "common": {
-                                "emit": {
-                                  "outputMapping": [1]
-                                }
-                              },
+                      "cast": {
+                        "type": {
+                          "decimal": {
+                            "scale": 2,
+                            "precision": 19,
+                            "nullability": "NULLABILITY_NULLABLE"
+                          }
+                        },
+                        "input": {
+                          "subquery": {
+                            "scalar": {
                               "input": {
-                                "aggregate": {
+                                "project": {
                                   "common": {
-                                    "direct": {
+                                    "emit": {
+                                      "outputMapping": [1]
                                     }
                                   },
                                   "input": {
-                                    "project": {
+                                    "aggregate": {
                                       "common": {
-                                        "emit": {
-                                          "outputMapping": [16]
+                                        "direct": {
                                         }
                                       },
                                       "input": {
-                                        "filter": {
+                                        "project": {
                                           "common": {
-                                            "direct": {
+                                            "emit": {
+                                              "outputMapping": [16]
                                             }
                                           },
                                           "input": {
-                                            "cross": {
+                                            "filter": {
                                               "common": {
                                                 "direct": {
                                                 }
                                               },
-                                              "left": {
+                                              "input": {
                                                 "cross": {
                                                   "common": {
                                                     "direct": {
                                                     }
                                                   },
                                                   "left": {
-                                                    "read": {
+                                                    "cross": {
                                                       "common": {
                                                         "direct": {
                                                         }
                                                       },
-                                                      "baseSchema": {
-                                                        "names": ["PS_PARTKEY", "PS_SUPPKEY", "PS_AVAILQTY", "PS_SUPPLYCOST", "PS_COMMENT"],
-                                                        "struct": {
-                                                          "types": [{
-                                                            "i64": {
+                                                      "left": {
+                                                        "read": {
+                                                          "common": {
+                                                            "direct": {
+                                                            }
+                                                          },
+                                                          "baseSchema": {
+                                                            "names": ["PS_PARTKEY", "PS_SUPPKEY", "PS_AVAILQTY", "PS_SUPPLYCOST", "PS_COMMENT"],
+                                                            "struct": {
+                                                              "types": [{
+                                                                "i64": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "i64": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "i64": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "decimal": {
+                                                                  "scale": 2,
+                                                                  "precision": 15,
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "string": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }],
                                                               "nullability": "NULLABILITY_REQUIRED"
                                                             }
-                                                          }, {
-                                                            "i64": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          }, {
-                                                            "i64": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          }, {
-                                                            "decimal": {
-                                                              "scale": 2,
-                                                              "precision": 15,
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          }, {
-                                                            "string": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          }],
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                          },
+                                                          "namedTable": {
+                                                            "names": ["PARTSUPP"]
+                                                          }
                                                         }
                                                       },
-                                                      "namedTable": {
-                                                        "names": ["PARTSUPP"]
+                                                      "right": {
+                                                        "read": {
+                                                          "common": {
+                                                            "direct": {
+                                                            }
+                                                          },
+                                                          "baseSchema": {
+                                                            "names": ["S_SUPPKEY", "S_NAME", "S_ADDRESS", "S_NATIONKEY", "S_PHONE", "S_ACCTBAL", "S_COMMENT"],
+                                                            "struct": {
+                                                              "types": [{
+                                                                "i64": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "string": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "string": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "i32": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "string": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "decimal": {
+                                                                  "scale": 2,
+                                                                  "precision": 15,
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }, {
+                                                                "string": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              }],
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          "namedTable": {
+                                                            "names": ["SUPPLIER"]
+                                                          }
+                                                        }
                                                       }
                                                     }
                                                   },
@@ -533,14 +592,10 @@
                                                         }
                                                       },
                                                       "baseSchema": {
-                                                        "names": ["S_SUPPKEY", "S_NAME", "S_ADDRESS", "S_NATIONKEY", "S_PHONE", "S_ACCTBAL", "S_COMMENT"],
+                                                        "names": ["N_NATIONKEY", "N_NAME", "N_REGIONKEY", "N_COMMENT"],
                                                         "struct": {
                                                           "types": [{
-                                                            "i64": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          }, {
-                                                            "string": {
+                                                            "i32": {
                                                               "nullability": "NULLABILITY_REQUIRED"
                                                             }
                                                           }, {
@@ -555,220 +610,204 @@
                                                             "string": {
                                                               "nullability": "NULLABILITY_REQUIRED"
                                                             }
-                                                          }, {
-                                                            "decimal": {
-                                                              "scale": 2,
-                                                              "precision": 15,
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          }, {
-                                                            "string": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
                                                           }],
                                                           "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       "namedTable": {
-                                                        "names": ["SUPPLIER"]
+                                                        "names": ["NATION"]
                                                       }
                                                     }
                                                   }
                                                 }
                                               },
-                                              "right": {
-                                                "read": {
-                                                  "common": {
-                                                    "direct": {
-                                                    }
-                                                  },
-                                                  "baseSchema": {
-                                                    "names": ["N_NATIONKEY", "N_NAME", "N_REGIONKEY", "N_COMMENT"],
-                                                    "struct": {
-                                                      "types": [{
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      }, {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      }, {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      }, {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      }],
+                                              "condition": {
+                                                "scalarFunction": {
+                                                  "outputType": {
+                                                    "bool": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
-                                                  "namedTable": {
-                                                    "names": ["NATION"]
-                                                  }
+                                                  "arguments": [{
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 1,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        },
+                                                        "arguments": [{
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 1
+                                                                }
+                                                              },
+                                                              "rootReference": {
+                                                              }
+                                                            }
+                                                          }
+                                                        }, {
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 5
+                                                                }
+                                                              },
+                                                              "rootReference": {
+                                                              }
+                                                            }
+                                                          }
+                                                        }]
+                                                      }
+                                                    }
+                                                  }, {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 1,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        },
+                                                        "arguments": [{
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 8
+                                                                }
+                                                              },
+                                                              "rootReference": {
+                                                              }
+                                                            }
+                                                          }
+                                                        }, {
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 12
+                                                                }
+                                                              },
+                                                              "rootReference": {
+                                                              }
+                                                            }
+                                                          }
+                                                        }]
+                                                      }
+                                                    }
+                                                  }, {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 1,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        },
+                                                        "arguments": [{
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 13
+                                                                }
+                                                              },
+                                                              "rootReference": {
+                                                              }
+                                                            }
+                                                          }
+                                                        }, {
+                                                          "value": {
+                                                            "literal": {
+                                                              "string": "JAPAN"
+                                                            }
+                                                          }
+                                                        }]
+                                                      }
+                                                    }
+                                                  }]
                                                 }
                                               }
                                             }
                                           },
-                                          "condition": {
+                                          "expressions": [{
                                             "scalarFunction": {
+                                              "functionReference": 2,
                                               "outputType": {
-                                                "bool": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 19,
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               "arguments": [{
                                                 "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 1,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    "arguments": [{
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 1
-                                                            }
-                                                          },
-                                                          "rootReference": {
-                                                          }
-                                                        }
-                                                      }
-                                                    }, {
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 5
-                                                            }
-                                                          },
-                                                          "rootReference": {
-                                                          }
-                                                        }
-                                                      }
-                                                    }]
-                                                  }
-                                                }
-                                              }, {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 1,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    "arguments": [{
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 8
-                                                            }
-                                                          },
-                                                          "rootReference": {
-                                                          }
-                                                        }
-                                                      }
-                                                    }, {
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 12
-                                                            }
-                                                          },
-                                                          "rootReference": {
-                                                          }
-                                                        }
-                                                      }
-                                                    }]
-                                                  }
-                                                }
-                                              }, {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 1,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    "arguments": [{
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 13
-                                                            }
-                                                          },
-                                                          "rootReference": {
-                                                          }
-                                                        }
-                                                      }
-                                                    }, {
-                                                      "value": {
-                                                        "literal": {
-                                                          "string": "JAPAN"
-                                                        }
-                                                      }
-                                                    }]
-                                                  }
-                                                }
-                                              }]
-                                            }
-                                          }
-                                        }
-                                      },
-                                      "expressions": [{
-                                        "scalarFunction": {
-                                          "functionReference": 2,
-                                          "outputType": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 19,
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          "arguments": [{
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 3
-                                                  }
-                                                },
-                                                "rootReference": {
-                                                }
-                                              }
-                                            }
-                                          }, {
-                                            "value": {
-                                              "cast": {
-                                                "type": {
-                                                  "decimal": {
-                                                    "precision": 19,
-                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                  }
-                                                },
-                                                "input": {
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 2
+                                                        "field": 3
                                                       }
                                                     },
                                                     "rootReference": {
                                                     }
                                                   }
+                                                }
+                                              }, {
+                                                "value": {
+                                                  "cast": {
+                                                    "type": {
+                                                      "decimal": {
+                                                        "precision": 19,
+                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                      }
+                                                    },
+                                                    "input": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 2
+                                                          }
+                                                        },
+                                                        "rootReference": {
+                                                        }
+                                                      }
+                                                    },
+                                                    "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                  }
+                                                }
+                                              }]
+                                            }
+                                          }]
+                                        }
+                                      },
+                                      "groupings": [{
+                                      }],
+                                      "measures": [{
+                                        "measure": {
+                                          "functionReference": 3,
+                                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 19,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "invocation": "AGGREGATION_INVOCATION_ALL",
+                                          "arguments": [{
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                  }
                                                 },
-                                                "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                "rootReference": {
+                                                }
                                               }
                                             }
                                           }]
@@ -776,20 +815,16 @@
                                       }]
                                     }
                                   },
-                                  "groupings": [{
-                                  }],
-                                  "measures": [{
-                                    "measure": {
-                                      "functionReference": 3,
-                                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                  "expressions": [{
+                                    "scalarFunction": {
+                                      "functionReference": 2,
                                       "outputType": {
                                         "decimal": {
-                                          "scale": 2,
+                                          "scale": 12,
                                           "precision": 19,
                                           "nullability": "NULLABILITY_NULLABLE"
                                         }
                                       },
-                                      "invocation": "AGGREGATION_INVOCATION_ALL",
                                       "arguments": [{
                                         "value": {
                                           "selection": {
@@ -801,48 +836,25 @@
                                             }
                                           }
                                         }
+                                      }, {
+                                        "value": {
+                                          "literal": {
+                                            "decimal": {
+                                              "value": "QEIPAAAAAAAAAAAAAAAAAA==",
+                                              "precision": 11,
+                                              "scale": 10
+                                            }
+                                          }
+                                        }
                                       }]
                                     }
                                   }]
                                 }
-                              },
-                              "expressions": [{
-                                "scalarFunction": {
-                                  "functionReference": 2,
-                                  "outputType": {
-                                    "decimal": {
-                                      "scale": 12,
-                                      "precision": 19,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "arguments": [{
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                          }
-                                        },
-                                        "rootReference": {
-                                        }
-                                      }
-                                    }
-                                  }, {
-                                    "value": {
-                                      "literal": {
-                                        "decimal": {
-                                          "value": "QEIPAAAAAAAAAAAAAAAAAA==",
-                                          "precision": 11,
-                                          "scale": 10
-                                        }
-                                      }
-                                    }
-                                  }]
-                                }
-                              }]
+                              }
                             }
                           }
-                        }
+                        },
+                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
                       }
                     }
                   }]

--- a/substrait_consumer/snapshots/producer/integration/tpch/q12-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q12-isthmus_plan.json
@@ -309,18 +309,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "MAIL"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "MAIL"
                                           }
                                         }
                                       }]
@@ -349,18 +339,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "SHIP"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "SHIP"
                                           }
                                         }
                                       }]

--- a/substrait_consumer/snapshots/producer/integration/tpch/q14-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q14-isthmus_plan.json
@@ -623,7 +623,7 @@
               "functionReference": 8,
               "outputType": {
                 "decimal": {
-                  "scale": 2,
+                  "scale": 6,
                   "precision": 19,
                   "nullability": "NULLABILITY_NULLABLE"
                 }

--- a/substrait_consumer/snapshots/producer/integration/tpch/q17-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q17-isthmus_plan.json
@@ -347,14 +347,26 @@
                                 },
                                 "arguments": [{
                                   "value": {
-                                    "selection": {
-                                      "directReference": {
-                                        "structField": {
-                                          "field": 4
+                                    "cast": {
+                                      "type": {
+                                        "decimal": {
+                                          "scale": 3,
+                                          "precision": 17,
+                                          "nullability": "NULLABILITY_REQUIRED"
                                         }
                                       },
-                                      "rootReference": {
-                                      }
+                                      "input": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 4
+                                            }
+                                          },
+                                          "rootReference": {
+                                          }
+                                        }
+                                      },
+                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
                                     }
                                   }
                                 }, {
@@ -653,7 +665,7 @@
               "functionReference": 6,
               "outputType": {
                 "decimal": {
-                  "scale": 5,
+                  "scale": 6,
                   "precision": 19,
                   "nullability": "NULLABILITY_NULLABLE"
                 }

--- a/substrait_consumer/snapshots/producer/integration/tpch/q18-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q18-isthmus_plan.json
@@ -503,20 +503,12 @@
                                                     }
                                                   }, {
                                                     "value": {
-                                                      "cast": {
-                                                        "type": {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 15,
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        "input": {
-                                                          "literal": {
-                                                            "i32": 300
-                                                          }
-                                                        },
-                                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                      "literal": {
+                                                        "decimal": {
+                                                          "value": "MHUAAAAAAAAAAAAAAAAAAA==",
+                                                          "precision": 15,
+                                                          "scale": 2
+                                                        }
                                                       }
                                                     }
                                                   }]

--- a/substrait_consumer/snapshots/producer/integration/tpch/q19-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q19-isthmus_plan.json
@@ -354,18 +354,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "SM CASE"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "SM CASE"
                                             }
                                           }
                                         }]
@@ -394,18 +384,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "SM BOX"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "SM BOX"
                                             }
                                           }
                                         }]
@@ -434,18 +414,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "SM PACK"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "SM PACK"
                                             }
                                           }
                                         }]
@@ -474,18 +444,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "SM PKG"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "SM PKG"
                                             }
                                           }
                                         }]
@@ -517,20 +477,12 @@
                                     }
                                   }, {
                                     "value": {
-                                      "cast": {
-                                        "type": {
-                                          "decimal": {
-                                            "scale": 2,
-                                            "precision": 15,
-                                            "nullability": "NULLABILITY_REQUIRED"
-                                          }
-                                        },
-                                        "input": {
-                                          "literal": {
-                                            "i32": 1
-                                          }
-                                        },
-                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                      "literal": {
+                                        "decimal": {
+                                          "value": "ZAAAAAAAAAAAAAAAAAAAAA==",
+                                          "precision": 15,
+                                          "scale": 2
+                                        }
                                       }
                                     }
                                   }]
@@ -687,18 +639,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "AIR"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "AIR"
                                             }
                                           }
                                         }]
@@ -727,18 +669,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "AIR REG"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "AIR REG"
                                             }
                                           }
                                         }]
@@ -886,18 +818,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "MED BAG"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "MED BAG"
                                             }
                                           }
                                         }]
@@ -926,18 +848,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "MED BOX"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "MED BOX"
                                             }
                                           }
                                         }]
@@ -966,18 +878,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "MED PKG"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "MED PKG"
                                             }
                                           }
                                         }]
@@ -1006,18 +908,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "MED PACK"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "MED PACK"
                                             }
                                           }
                                         }]
@@ -1049,20 +941,12 @@
                                     }
                                   }, {
                                     "value": {
-                                      "cast": {
-                                        "type": {
-                                          "decimal": {
-                                            "scale": 2,
-                                            "precision": 15,
-                                            "nullability": "NULLABILITY_REQUIRED"
-                                          }
-                                        },
-                                        "input": {
-                                          "literal": {
-                                            "i32": 10
-                                          }
-                                        },
-                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                      "literal": {
+                                        "decimal": {
+                                          "value": "6AMAAAAAAAAAAAAAAAAAAA==",
+                                          "precision": 15,
+                                          "scale": 2
+                                        }
                                       }
                                     }
                                   }]
@@ -1219,18 +1103,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "AIR"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "AIR"
                                             }
                                           }
                                         }]
@@ -1259,18 +1133,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "AIR REG"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "AIR REG"
                                             }
                                           }
                                         }]
@@ -1418,18 +1282,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "LG CASE"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "LG CASE"
                                             }
                                           }
                                         }]
@@ -1458,18 +1312,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "LG BOX"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "LG BOX"
                                             }
                                           }
                                         }]
@@ -1498,18 +1342,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "LG PACK"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "LG PACK"
                                             }
                                           }
                                         }]
@@ -1538,18 +1372,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "LG PKG"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "LG PKG"
                                             }
                                           }
                                         }]
@@ -1581,20 +1405,12 @@
                                     }
                                   }, {
                                     "value": {
-                                      "cast": {
-                                        "type": {
-                                          "decimal": {
-                                            "scale": 2,
-                                            "precision": 15,
-                                            "nullability": "NULLABILITY_REQUIRED"
-                                          }
-                                        },
-                                        "input": {
-                                          "literal": {
-                                            "i32": 20
-                                          }
-                                        },
-                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                      "literal": {
+                                        "decimal": {
+                                          "value": "0AcAAAAAAAAAAAAAAAAAAA==",
+                                          "precision": 15,
+                                          "scale": 2
+                                        }
                                       }
                                     }
                                   }]
@@ -1751,18 +1567,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "AIR"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "AIR"
                                             }
                                           }
                                         }]
@@ -1791,18 +1597,8 @@
                                           }
                                         }, {
                                           "value": {
-                                            "cast": {
-                                              "type": {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "fixedChar": "AIR REG"
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            "literal": {
+                                              "string": "AIR REG"
                                             }
                                           }
                                         }]

--- a/substrait_consumer/snapshots/producer/integration/tpch/q20-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q20-isthmus_plan.json
@@ -408,8 +408,9 @@
                                                     "cast": {
                                                       "type": {
                                                         "decimal": {
+                                                          "scale": 3,
                                                           "precision": 19,
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       "input": {
@@ -428,317 +429,362 @@
                                                   }
                                                 }, {
                                                   "value": {
-                                                    "subquery": {
-                                                      "scalar": {
-                                                        "input": {
-                                                          "project": {
-                                                            "common": {
-                                                              "emit": {
-                                                                "outputMapping": [1]
-                                                              }
-                                                            },
+                                                    "cast": {
+                                                      "type": {
+                                                        "decimal": {
+                                                          "scale": 3,
+                                                          "precision": 19,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "input": {
+                                                        "subquery": {
+                                                          "scalar": {
                                                             "input": {
-                                                              "aggregate": {
+                                                              "project": {
                                                                 "common": {
-                                                                  "direct": {
+                                                                  "emit": {
+                                                                    "outputMapping": [1]
                                                                   }
                                                                 },
                                                                 "input": {
-                                                                  "project": {
+                                                                  "aggregate": {
                                                                     "common": {
-                                                                      "emit": {
-                                                                        "outputMapping": [16]
+                                                                      "direct": {
                                                                       }
                                                                     },
                                                                     "input": {
-                                                                      "filter": {
+                                                                      "project": {
                                                                         "common": {
-                                                                          "direct": {
+                                                                          "emit": {
+                                                                            "outputMapping": [16]
                                                                           }
                                                                         },
                                                                         "input": {
-                                                                          "read": {
+                                                                          "filter": {
                                                                             "common": {
                                                                               "direct": {
                                                                               }
                                                                             },
-                                                                            "baseSchema": {
-                                                                              "names": ["L_ORDERKEY", "L_PARTKEY", "L_SUPPKEY", "L_LINENUMBER", "L_QUANTITY", "L_EXTENDEDPRICE", "L_DISCOUNT", "L_TAX", "L_RETURNFLAG", "L_LINESTATUS", "L_SHIPDATE", "L_COMMITDATE", "L_RECEIPTDATE", "L_SHIPINSTRUCT", "L_SHIPMODE", "L_COMMENT"],
-                                                                              "struct": {
-                                                                                "types": [{
-                                                                                  "i64": {
+                                                                            "input": {
+                                                                              "read": {
+                                                                                "common": {
+                                                                                  "direct": {
+                                                                                  }
+                                                                                },
+                                                                                "baseSchema": {
+                                                                                  "names": ["L_ORDERKEY", "L_PARTKEY", "L_SUPPKEY", "L_LINENUMBER", "L_QUANTITY", "L_EXTENDEDPRICE", "L_DISCOUNT", "L_TAX", "L_RETURNFLAG", "L_LINESTATUS", "L_SHIPDATE", "L_COMMITDATE", "L_RECEIPTDATE", "L_SHIPINSTRUCT", "L_SHIPMODE", "L_COMMENT"],
+                                                                                  "struct": {
+                                                                                    "types": [{
+                                                                                      "i64": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "i64": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "i64": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "i64": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "decimal": {
+                                                                                        "scale": 2,
+                                                                                        "precision": 15,
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "decimal": {
+                                                                                        "scale": 2,
+                                                                                        "precision": 15,
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "decimal": {
+                                                                                        "scale": 2,
+                                                                                        "precision": 15,
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "decimal": {
+                                                                                        "scale": 2,
+                                                                                        "precision": 15,
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "date": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "date": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "date": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }, {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }],
                                                                                     "nullability": "NULLABILITY_REQUIRED"
                                                                                   }
-                                                                                }, {
-                                                                                  "i64": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "i64": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "i64": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "decimal": {
-                                                                                    "scale": 2,
-                                                                                    "precision": 15,
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "decimal": {
-                                                                                    "scale": 2,
-                                                                                    "precision": 15,
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "decimal": {
-                                                                                    "scale": 2,
-                                                                                    "precision": 15,
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "decimal": {
-                                                                                    "scale": 2,
-                                                                                    "precision": 15,
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "string": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "string": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "date": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "date": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "date": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "string": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "string": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }, {
-                                                                                  "string": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                }],
-                                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                                                },
+                                                                                "namedTable": {
+                                                                                  "names": ["LINEITEM"]
+                                                                                }
                                                                               }
                                                                             },
-                                                                            "namedTable": {
-                                                                              "names": ["LINEITEM"]
+                                                                            "condition": {
+                                                                              "scalarFunction": {
+                                                                                "outputType": {
+                                                                                  "bool": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                "arguments": [{
+                                                                                  "value": {
+                                                                                    "scalarFunction": {
+                                                                                      "functionReference": 3,
+                                                                                      "outputType": {
+                                                                                        "bool": {
+                                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                                        }
+                                                                                      },
+                                                                                      "arguments": [{
+                                                                                        "value": {
+                                                                                          "selection": {
+                                                                                            "directReference": {
+                                                                                              "structField": {
+                                                                                                "field": 1
+                                                                                              }
+                                                                                            },
+                                                                                            "rootReference": {
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }, {
+                                                                                        "value": {
+                                                                                          "selection": {
+                                                                                            "directReference": {
+                                                                                              "structField": {
+                                                                                              }
+                                                                                            },
+                                                                                            "outerReference": {
+                                                                                              "stepsOut": 1
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }]
+                                                                                    }
+                                                                                  }
+                                                                                }, {
+                                                                                  "value": {
+                                                                                    "scalarFunction": {
+                                                                                      "functionReference": 3,
+                                                                                      "outputType": {
+                                                                                        "bool": {
+                                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                                        }
+                                                                                      },
+                                                                                      "arguments": [{
+                                                                                        "value": {
+                                                                                          "selection": {
+                                                                                            "directReference": {
+                                                                                              "structField": {
+                                                                                                "field": 2
+                                                                                              }
+                                                                                            },
+                                                                                            "rootReference": {
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }, {
+                                                                                        "value": {
+                                                                                          "selection": {
+                                                                                            "directReference": {
+                                                                                              "structField": {
+                                                                                                "field": 1
+                                                                                              }
+                                                                                            },
+                                                                                            "outerReference": {
+                                                                                              "stepsOut": 1
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }]
+                                                                                    }
+                                                                                  }
+                                                                                }, {
+                                                                                  "value": {
+                                                                                    "scalarFunction": {
+                                                                                      "functionReference": 4,
+                                                                                      "outputType": {
+                                                                                        "bool": {
+                                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                                        }
+                                                                                      },
+                                                                                      "arguments": [{
+                                                                                        "value": {
+                                                                                          "selection": {
+                                                                                            "directReference": {
+                                                                                              "structField": {
+                                                                                                "field": 10
+                                                                                              }
+                                                                                            },
+                                                                                            "rootReference": {
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }, {
+                                                                                        "value": {
+                                                                                          "cast": {
+                                                                                            "type": {
+                                                                                              "date": {
+                                                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                                                              }
+                                                                                            },
+                                                                                            "input": {
+                                                                                              "literal": {
+                                                                                                "fixedChar": "1994-01-01"
+                                                                                              }
+                                                                                            },
+                                                                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                                          }
+                                                                                        }
+                                                                                      }]
+                                                                                    }
+                                                                                  }
+                                                                                }, {
+                                                                                  "value": {
+                                                                                    "scalarFunction": {
+                                                                                      "functionReference": 5,
+                                                                                      "outputType": {
+                                                                                        "bool": {
+                                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                                        }
+                                                                                      },
+                                                                                      "arguments": [{
+                                                                                        "value": {
+                                                                                          "selection": {
+                                                                                            "directReference": {
+                                                                                              "structField": {
+                                                                                                "field": 10
+                                                                                              }
+                                                                                            },
+                                                                                            "rootReference": {
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }, {
+                                                                                        "value": {
+                                                                                          "cast": {
+                                                                                            "type": {
+                                                                                              "date": {
+                                                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                                                              }
+                                                                                            },
+                                                                                            "input": {
+                                                                                              "literal": {
+                                                                                                "fixedChar": "1995-01-01"
+                                                                                              }
+                                                                                            },
+                                                                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                                          }
+                                                                                        }
+                                                                                      }]
+                                                                                    }
+                                                                                  }
+                                                                                }]
+                                                                              }
                                                                             }
                                                                           }
                                                                         },
-                                                                        "condition": {
-                                                                          "scalarFunction": {
-                                                                            "outputType": {
-                                                                              "bool": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                                        "expressions": [{
+                                                                          "selection": {
+                                                                            "directReference": {
+                                                                              "structField": {
+                                                                                "field": 4
                                                                               }
                                                                             },
-                                                                            "arguments": [{
-                                                                              "value": {
-                                                                                "scalarFunction": {
-                                                                                  "functionReference": 3,
-                                                                                  "outputType": {
-                                                                                    "bool": {
-                                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                                    }
-                                                                                  },
-                                                                                  "arguments": [{
-                                                                                    "value": {
-                                                                                      "selection": {
-                                                                                        "directReference": {
-                                                                                          "structField": {
-                                                                                            "field": 1
-                                                                                          }
-                                                                                        },
-                                                                                        "rootReference": {
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }, {
-                                                                                    "value": {
-                                                                                      "selection": {
-                                                                                        "directReference": {
-                                                                                          "structField": {
-                                                                                          }
-                                                                                        },
-                                                                                        "outerReference": {
-                                                                                          "stepsOut": 1
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }]
-                                                                                }
-                                                                              }
-                                                                            }, {
-                                                                              "value": {
-                                                                                "scalarFunction": {
-                                                                                  "functionReference": 3,
-                                                                                  "outputType": {
-                                                                                    "bool": {
-                                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                                    }
-                                                                                  },
-                                                                                  "arguments": [{
-                                                                                    "value": {
-                                                                                      "selection": {
-                                                                                        "directReference": {
-                                                                                          "structField": {
-                                                                                            "field": 2
-                                                                                          }
-                                                                                        },
-                                                                                        "rootReference": {
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }, {
-                                                                                    "value": {
-                                                                                      "selection": {
-                                                                                        "directReference": {
-                                                                                          "structField": {
-                                                                                            "field": 1
-                                                                                          }
-                                                                                        },
-                                                                                        "outerReference": {
-                                                                                          "stepsOut": 1
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }]
-                                                                                }
-                                                                              }
-                                                                            }, {
-                                                                              "value": {
-                                                                                "scalarFunction": {
-                                                                                  "functionReference": 4,
-                                                                                  "outputType": {
-                                                                                    "bool": {
-                                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                                    }
-                                                                                  },
-                                                                                  "arguments": [{
-                                                                                    "value": {
-                                                                                      "selection": {
-                                                                                        "directReference": {
-                                                                                          "structField": {
-                                                                                            "field": 10
-                                                                                          }
-                                                                                        },
-                                                                                        "rootReference": {
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }, {
-                                                                                    "value": {
-                                                                                      "cast": {
-                                                                                        "type": {
-                                                                                          "date": {
-                                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                                          }
-                                                                                        },
-                                                                                        "input": {
-                                                                                          "literal": {
-                                                                                            "fixedChar": "1994-01-01"
-                                                                                          }
-                                                                                        },
-                                                                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                                                      }
-                                                                                    }
-                                                                                  }]
-                                                                                }
-                                                                              }
-                                                                            }, {
-                                                                              "value": {
-                                                                                "scalarFunction": {
-                                                                                  "functionReference": 5,
-                                                                                  "outputType": {
-                                                                                    "bool": {
-                                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                                    }
-                                                                                  },
-                                                                                  "arguments": [{
-                                                                                    "value": {
-                                                                                      "selection": {
-                                                                                        "directReference": {
-                                                                                          "structField": {
-                                                                                            "field": 10
-                                                                                          }
-                                                                                        },
-                                                                                        "rootReference": {
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }, {
-                                                                                    "value": {
-                                                                                      "cast": {
-                                                                                        "type": {
-                                                                                          "date": {
-                                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                                          }
-                                                                                        },
-                                                                                        "input": {
-                                                                                          "literal": {
-                                                                                            "fixedChar": "1995-01-01"
-                                                                                          }
-                                                                                        },
-                                                                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                                                      }
-                                                                                    }
-                                                                                  }]
-                                                                                }
-                                                                              }
-                                                                            }]
+                                                                            "rootReference": {
+                                                                            }
                                                                           }
-                                                                        }
+                                                                        }]
                                                                       }
                                                                     },
-                                                                    "expressions": [{
-                                                                      "selection": {
-                                                                        "directReference": {
-                                                                          "structField": {
-                                                                            "field": 4
+                                                                    "groupings": [{
+                                                                    }],
+                                                                    "measures": [{
+                                                                      "measure": {
+                                                                        "functionReference": 6,
+                                                                        "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                                        "outputType": {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_NULLABLE"
                                                                           }
                                                                         },
-                                                                        "rootReference": {
-                                                                        }
+                                                                        "invocation": "AGGREGATION_INVOCATION_ALL",
+                                                                        "arguments": [{
+                                                                          "value": {
+                                                                            "selection": {
+                                                                              "directReference": {
+                                                                                "structField": {
+                                                                                }
+                                                                              },
+                                                                              "rootReference": {
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }]
                                                                       }
                                                                     }]
                                                                   }
                                                                 },
-                                                                "groupings": [{
-                                                                }],
-                                                                "measures": [{
-                                                                  "measure": {
-                                                                    "functionReference": 6,
-                                                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                                "expressions": [{
+                                                                  "scalarFunction": {
+                                                                    "functionReference": 7,
                                                                     "outputType": {
                                                                       "decimal": {
-                                                                        "scale": 2,
-                                                                        "precision": 15,
+                                                                        "scale": 3,
+                                                                        "precision": 17,
                                                                         "nullability": "NULLABILITY_NULLABLE"
                                                                       }
                                                                     },
-                                                                    "invocation": "AGGREGATION_INVOCATION_ALL",
                                                                     "arguments": [{
+                                                                      "value": {
+                                                                        "literal": {
+                                                                          "decimal": {
+                                                                            "value": "BQAAAAAAAAAAAAAAAAAAAA==",
+                                                                            "precision": 2,
+                                                                            "scale": 1
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }, {
                                                                       "value": {
                                                                         "selection": {
                                                                           "directReference": {
@@ -753,44 +799,11 @@
                                                                   }
                                                                 }]
                                                               }
-                                                            },
-                                                            "expressions": [{
-                                                              "scalarFunction": {
-                                                                "functionReference": 7,
-                                                                "outputType": {
-                                                                  "decimal": {
-                                                                    "scale": 3,
-                                                                    "precision": 17,
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                "arguments": [{
-                                                                  "value": {
-                                                                    "literal": {
-                                                                      "decimal": {
-                                                                        "value": "BQAAAAAAAAAAAAAAAAAAAA==",
-                                                                        "precision": 2,
-                                                                        "scale": 1
-                                                                      }
-                                                                    }
-                                                                  }
-                                                                }, {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {
-                                                                      }
-                                                                    }
-                                                                  }
-                                                                }]
-                                                              }
-                                                            }]
+                                                            }
                                                           }
                                                         }
-                                                      }
+                                                      },
+                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
                                                     }
                                                   }
                                                 }]

--- a/substrait_consumer/snapshots/producer/integration/tpch/q22-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q22-isthmus_plan.json
@@ -211,18 +211,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "13"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "13"
                                           }
                                         }
                                       }]
@@ -275,18 +265,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "31"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "31"
                                           }
                                         }
                                       }]
@@ -339,18 +319,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "23"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "23"
                                           }
                                         }
                                       }]
@@ -403,18 +373,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "29"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "29"
                                           }
                                         }
                                       }]
@@ -467,18 +427,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "30"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "30"
                                           }
                                         }
                                       }]
@@ -531,18 +481,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "18"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "18"
                                           }
                                         }
                                       }]
@@ -595,18 +535,8 @@
                                         }
                                       }, {
                                         "value": {
-                                          "cast": {
-                                            "type": {
-                                              "string": {
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "input": {
-                                              "literal": {
-                                                "fixedChar": "17"
-                                              }
-                                            },
-                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          "literal": {
+                                            "string": "17"
                                           }
                                         }
                                       }]
@@ -744,7 +674,7 @@
                                                                   "literal": {
                                                                     "decimal": {
                                                                       "value": "AAAAAAAAAAAAAAAAAAAAAA==",
-                                                                      "precision": 3,
+                                                                      "precision": 15,
                                                                       "scale": 2
                                                                     }
                                                                   }
@@ -808,18 +738,8 @@
                                                                       }
                                                                     }, {
                                                                       "value": {
-                                                                        "cast": {
-                                                                          "type": {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          "input": {
-                                                                            "literal": {
-                                                                              "fixedChar": "13"
-                                                                            }
-                                                                          },
-                                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                        "literal": {
+                                                                          "string": "13"
                                                                         }
                                                                       }
                                                                     }]
@@ -872,18 +792,8 @@
                                                                       }
                                                                     }, {
                                                                       "value": {
-                                                                        "cast": {
-                                                                          "type": {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          "input": {
-                                                                            "literal": {
-                                                                              "fixedChar": "31"
-                                                                            }
-                                                                          },
-                                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                        "literal": {
+                                                                          "string": "31"
                                                                         }
                                                                       }
                                                                     }]
@@ -936,18 +846,8 @@
                                                                       }
                                                                     }, {
                                                                       "value": {
-                                                                        "cast": {
-                                                                          "type": {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          "input": {
-                                                                            "literal": {
-                                                                              "fixedChar": "23"
-                                                                            }
-                                                                          },
-                                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                        "literal": {
+                                                                          "string": "23"
                                                                         }
                                                                       }
                                                                     }]
@@ -1000,18 +900,8 @@
                                                                       }
                                                                     }, {
                                                                       "value": {
-                                                                        "cast": {
-                                                                          "type": {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          "input": {
-                                                                            "literal": {
-                                                                              "fixedChar": "29"
-                                                                            }
-                                                                          },
-                                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                        "literal": {
+                                                                          "string": "29"
                                                                         }
                                                                       }
                                                                     }]
@@ -1064,18 +954,8 @@
                                                                       }
                                                                     }, {
                                                                       "value": {
-                                                                        "cast": {
-                                                                          "type": {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          "input": {
-                                                                            "literal": {
-                                                                              "fixedChar": "30"
-                                                                            }
-                                                                          },
-                                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                        "literal": {
+                                                                          "string": "30"
                                                                         }
                                                                       }
                                                                     }]
@@ -1128,18 +1008,8 @@
                                                                       }
                                                                     }, {
                                                                       "value": {
-                                                                        "cast": {
-                                                                          "type": {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          "input": {
-                                                                            "literal": {
-                                                                              "fixedChar": "18"
-                                                                            }
-                                                                          },
-                                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                        "literal": {
+                                                                          "string": "18"
                                                                         }
                                                                       }
                                                                     }]
@@ -1192,18 +1062,8 @@
                                                                       }
                                                                     }, {
                                                                       "value": {
-                                                                        "cast": {
-                                                                          "type": {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          "input": {
-                                                                            "literal": {
-                                                                              "fixedChar": "17"
-                                                                            }
-                                                                          },
-                                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                        "literal": {
+                                                                          "string": "17"
                                                                         }
                                                                       }
                                                                     }]

--- a/substrait_consumer/snapshots/results/integration/tpch/q19-isthmus-duckdb_outcome.txt
+++ b/substrait_consumer/snapshots/results/integration/tpch/q19-isthmus-duckdb_outcome.txt
@@ -1,1 +1,1 @@
-<class 'duckdb.duckdb.InternalException'>
+{'schema': True, 'data': True}


### PR DESCRIPTION
This PRupdates the `substrait-java` git submodule to the next commit,
`f15cbabd`, which breaks some of the snapshot tests.

The PR  also updates the plan snapshots of several tests of TPC-H queries
for Isthmus. The plans have, in parts, change substatntially and I have
not verified all changes in detail. However, the version of Calcite that
Isthmus uses has changed in this update, so major plan changes seem
reasonable.




