### PR TITLE
chore: update `substrait-java` git submodule to latest version

### DIFF
--- a/substrait_consumer/snapshots/producer/integration/tpch/q01-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q01-isthmus_plan.json
@@ -212,7 +212,7 @@
                                   "value": {
                                     "literal": {
                                       "intervalDayToSecond": {
-                                        "seconds": 10368,
+                                        "days": 120,
                                         "precision": 6
                                       }
                                     }


### PR DESCRIPTION
This commit updates the `substrait-java` git submodule to its latest
verstion as of today, namely v0.50.0.

The PR also updates one plan snapshot of an Isthmus test due to the
version change in this PR. The plan changes the members of an
`intervalDaysToSeconds`, so I suppose it is due to
substrait-io/substrait-java#335, which fixes a bug related to that
message type.