### PR TITLE
chore: update `substrait-java` git submodule to v0.51.0 

### DIFF
--- a/substrait_consumer/snapshots/producer/integration/tpch/q01-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q01-isthmus_plan.json
@@ -271,7 +271,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 4,
-                          "precision": 19,
+                          "precision": 31,
                           "nullability": "NULLABILITY_REQUIRED"
                         }
                       },
@@ -339,7 +339,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 6,
-                          "precision": 19,
+                          "precision": 38,
                           "nullability": "NULLABILITY_REQUIRED"
                         }
                       },
@@ -350,7 +350,7 @@
                             "outputType": {
                               "decimal": {
                                 "scale": 4,
-                                "precision": 19,
+                                "precision": 31,
                                 "nullability": "NULLABILITY_REQUIRED"
                               }
                             },
@@ -553,7 +553,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 4,
-                      "precision": 19,
+                      "precision": 31,
                       "nullability": "NULLABILITY_NULLABLE"
                     }
                   },
@@ -579,7 +579,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 6,
-                      "precision": 19,
+                      "precision": 38,
                       "nullability": "NULLABILITY_NULLABLE"
                     }
                   },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q03-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q03-isthmus_plan.json
@@ -537,7 +537,7 @@
                               "outputType": {
                                 "decimal": {
                                   "scale": 4,
-                                  "precision": 19,
+                                  "precision": 31,
                                   "nullability": "NULLABILITY_REQUIRED"
                                 }
                               },
@@ -641,7 +641,7 @@
                           "outputType": {
                             "decimal": {
                               "scale": 4,
-                              "precision": 19,
+                              "precision": 31,
                               "nullability": "NULLABILITY_NULLABLE"
                             }
                           },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q05-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q05-isthmus_plan.json
@@ -784,7 +784,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 4,
-                          "precision": 19,
+                          "precision": 31,
                           "nullability": "NULLABILITY_REQUIRED"
                         }
                       },
@@ -868,7 +868,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 4,
-                      "precision": 19,
+                      "precision": 31,
                       "nullability": "NULLABILITY_NULLABLE"
                     }
                   },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q06-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q06-isthmus_plan.json
@@ -371,7 +371,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 4,
-                      "precision": 19,
+                      "precision": 30,
                       "nullability": "NULLABILITY_REQUIRED"
                     }
                   },
@@ -413,7 +413,7 @@
               "outputType": {
                 "decimal": {
                   "scale": 4,
-                  "precision": 19,
+                  "precision": 30,
                   "nullability": "NULLABILITY_NULLABLE"
                 }
               },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q07-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q07-isthmus_plan.json
@@ -922,7 +922,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 4,
-                          "precision": 19,
+                          "precision": 31,
                           "nullability": "NULLABILITY_REQUIRED"
                         }
                       },
@@ -1026,7 +1026,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 4,
-                      "precision": 19,
+                      "precision": 31,
                       "nullability": "NULLABILITY_NULLABLE"
                     }
                   },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q08-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q08-isthmus_plan.json
@@ -1021,7 +1021,7 @@
                                 "outputType": {
                                   "decimal": {
                                     "scale": 4,
-                                    "precision": 19,
+                                    "precision": 31,
                                     "nullability": "NULLABILITY_REQUIRED"
                                   }
                                 },
@@ -1089,7 +1089,7 @@
                             "literal": {
                               "decimal": {
                                 "value": "AAAAAAAAAAAAAAAAAAAAAA==",
-                                "precision": 19,
+                                "precision": 31,
                                 "scale": 4
                               }
                             }
@@ -1101,7 +1101,7 @@
                           "outputType": {
                             "decimal": {
                               "scale": 4,
-                              "precision": 19,
+                              "precision": 31,
                               "nullability": "NULLABILITY_REQUIRED"
                             }
                           },
@@ -1185,7 +1185,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 4,
-                          "precision": 19,
+                          "precision": 31,
                           "nullability": "NULLABILITY_NULLABLE"
                         }
                       },
@@ -1211,7 +1211,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 4,
-                          "precision": 19,
+                          "precision": 31,
                           "nullability": "NULLABILITY_NULLABLE"
                         }
                       },
@@ -1248,7 +1248,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 6,
-                      "precision": 19,
+                      "precision": 38,
                       "nullability": "NULLABILITY_NULLABLE"
                     }
                   },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q09-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q09-isthmus_plan.json
@@ -755,7 +755,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 4,
-                          "precision": 19,
+                          "precision": 32,
                           "nullability": "NULLABILITY_REQUIRED"
                         }
                       },
@@ -766,7 +766,7 @@
                             "outputType": {
                               "decimal": {
                                 "scale": 4,
-                                "precision": 19,
+                                "precision": 31,
                                 "nullability": "NULLABILITY_REQUIRED"
                               }
                             },
@@ -836,7 +836,7 @@
                             "outputType": {
                               "decimal": {
                                 "scale": 4,
-                                "precision": 19,
+                                "precision": 30,
                                 "nullability": "NULLABILITY_REQUIRED"
                               }
                             },
@@ -901,7 +901,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 4,
-                      "precision": 19,
+                      "precision": 32,
                       "nullability": "NULLABILITY_NULLABLE"
                     }
                   },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q10-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q10-isthmus_plan.json
@@ -654,7 +654,7 @@
                               "outputType": {
                                 "decimal": {
                                   "scale": 4,
-                                  "precision": 19,
+                                  "precision": 31,
                                   "nullability": "NULLABILITY_REQUIRED"
                                 }
                               },
@@ -798,7 +798,7 @@
                           "outputType": {
                             "decimal": {
                               "scale": 4,
-                              "precision": 19,
+                              "precision": 31,
                               "nullability": "NULLABILITY_NULLABLE"
                             }
                           },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q11-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q11-isthmus_plan.json
@@ -339,7 +339,7 @@
                           "outputType": {
                             "decimal": {
                               "scale": 2,
-                              "precision": 19,
+                              "precision": 34,
                               "nullability": "NULLABILITY_REQUIRED"
                             }
                           },
@@ -360,7 +360,8 @@
                               "cast": {
                                 "type": {
                                   "decimal": {
-                                    "precision": 19,
+                                    "scale": 2,
+                                    "precision": 21,
                                     "nullability": "NULLABILITY_REQUIRED"
                                   }
                                 },
@@ -402,7 +403,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 2,
-                          "precision": 19,
+                          "precision": 34,
                           "nullability": "NULLABILITY_NULLABLE"
                         }
                       },
@@ -434,14 +435,26 @@
                   },
                   "arguments": [{
                     "value": {
-                      "selection": {
-                        "directReference": {
-                          "structField": {
-                            "field": 1
+                      "cast": {
+                        "type": {
+                          "decimal": {
+                            "scale": 6,
+                            "precision": 38,
+                            "nullability": "NULLABILITY_NULLABLE"
                           }
                         },
-                        "rootReference": {
-                        }
+                        "input": {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 1
+                              }
+                            },
+                            "rootReference": {
+                            }
+                          }
+                        },
+                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
                       }
                     }
                   }, {
@@ -449,8 +462,8 @@
                       "cast": {
                         "type": {
                           "decimal": {
-                            "scale": 2,
-                            "precision": 19,
+                            "scale": 6,
+                            "precision": 38,
                             "nullability": "NULLABILITY_NULLABLE"
                           }
                         },
@@ -741,7 +754,7 @@
                                               "outputType": {
                                                 "decimal": {
                                                   "scale": 2,
-                                                  "precision": 19,
+                                                  "precision": 34,
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -762,7 +775,8 @@
                                                   "cast": {
                                                     "type": {
                                                       "decimal": {
-                                                        "precision": 19,
+                                                        "scale": 2,
+                                                        "precision": 21,
                                                         "nullability": "NULLABILITY_REQUIRED"
                                                       }
                                                     },
@@ -794,7 +808,7 @@
                                           "outputType": {
                                             "decimal": {
                                               "scale": 2,
-                                              "precision": 19,
+                                              "precision": 34,
                                               "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
@@ -821,7 +835,7 @@
                                       "outputType": {
                                         "decimal": {
                                           "scale": 12,
-                                          "precision": 19,
+                                          "precision": 38,
                                           "nullability": "NULLABILITY_NULLABLE"
                                         }
                                       },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q14-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q14-isthmus_plan.json
@@ -417,7 +417,7 @@
                             "outputType": {
                               "decimal": {
                                 "scale": 4,
-                                "precision": 19,
+                                "precision": 31,
                                 "nullability": "NULLABILITY_REQUIRED"
                               }
                             },
@@ -485,7 +485,7 @@
                         "literal": {
                           "decimal": {
                             "value": "AAAAAAAAAAAAAAAAAAAAAA==",
-                            "precision": 19,
+                            "precision": 31,
                             "scale": 4
                           }
                         }
@@ -497,7 +497,7 @@
                       "outputType": {
                         "decimal": {
                           "scale": 4,
-                          "precision": 19,
+                          "precision": 31,
                           "nullability": "NULLABILITY_REQUIRED"
                         }
                       },
@@ -571,7 +571,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 4,
-                      "precision": 19,
+                      "precision": 31,
                       "nullability": "NULLABILITY_NULLABLE"
                     }
                   },
@@ -596,7 +596,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 4,
-                      "precision": 19,
+                      "precision": 31,
                       "nullability": "NULLABILITY_NULLABLE"
                     }
                   },
@@ -624,7 +624,7 @@
               "outputType": {
                 "decimal": {
                   "scale": 6,
-                  "precision": 19,
+                  "precision": 38,
                   "nullability": "NULLABILITY_NULLABLE"
                 }
               },
@@ -635,7 +635,7 @@
                     "outputType": {
                       "decimal": {
                         "scale": 6,
-                        "precision": 19,
+                        "precision": 36,
                         "nullability": "NULLABILITY_NULLABLE"
                       }
                     },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q17-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q17-isthmus_plan.json
@@ -666,7 +666,7 @@
               "outputType": {
                 "decimal": {
                   "scale": 6,
-                  "precision": 19,
+                  "precision": 20,
                   "nullability": "NULLABILITY_NULLABLE"
                 }
               },

--- a/substrait_consumer/snapshots/producer/integration/tpch/q19-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q19-isthmus_plan.json
@@ -1651,7 +1651,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 4,
-                      "precision": 19,
+                      "precision": 31,
                       "nullability": "NULLABILITY_REQUIRED"
                     }
                   },
@@ -1725,7 +1725,7 @@
               "outputType": {
                 "decimal": {
                   "scale": 4,
-                  "precision": 19,
+                  "precision": 31,
                   "nullability": "NULLABILITY_NULLABLE"
                 }
               },

--- a/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_computation-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_computation-isthmus_plan.json
@@ -141,7 +141,7 @@
               "outputType": {
                 "decimal": {
                   "scale": 2,
-                  "precision": 19,
+                  "precision": 25,
                   "nullability": "NULLABILITY_NULLABLE"
                 }
               },

--- a/substrait_consumer/snapshots/producer/relation/aggregate/compute_within_aggregate-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/compute_within_aggregate-isthmus_plan.json
@@ -91,7 +91,7 @@
                   "outputType": {
                     "decimal": {
                       "scale": 2,
-                      "precision": 19,
+                      "precision": 25,
                       "nullability": "NULLABILITY_REQUIRED"
                     }
                   },
@@ -139,7 +139,7 @@
               "outputType": {
                 "decimal": {
                   "scale": 2,
-                  "precision": 19,
+                  "precision": 25,
                   "nullability": "NULLABILITY_NULLABLE"
                 }
               },

--- a/substrait_consumer/snapshots/producer/relation/project/extended_project-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/project/extended_project-isthmus_plan.json
@@ -123,7 +123,7 @@
               "outputType": {
                 "decimal": {
                   "scale": 2,
-                  "precision": 19,
+                  "precision": 25,
                   "nullability": "NULLABILITY_REQUIRED"
                 }
               },


### PR DESCRIPTION
This is the latest version that runs with just one fix. The breaking
change until there is substrait-io/substrait-java#350, which changes
which types are used in some places. Consequently, some of the plans
generated by Isthmus change: in several occasions, the precision and/or
scale of decimal types changes and, in one instance, a new cast to a
decimal type with a different precision is inserted.