### PR TITLE
chore(deps): update substrait-java to next (breaking) version

### DIFF
--- a/substrait_consumer/snapshots/producer/function/arithmetic/abs-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/abs-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "abs:i32"
     }
   }],
@@ -69,6 +70,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "i32": {
                       "nullability": "NULLABILITY_NULLABLE"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/acos-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/acos-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "acos:fp64"
     }
   }],
@@ -125,6 +126,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -133,7 +135,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/add-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/add-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "add:i64_i64"
     }
   }],
@@ -85,6 +86,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "i64": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/asin-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/asin-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "asin:fp64"
     }
   }],
@@ -125,6 +126,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -133,7 +135,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/atan-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/atan-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "atan:fp64"
     }
   }],
@@ -125,6 +126,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -133,7 +135,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/atan2-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/atan2-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "atan2:fp64_fp64"
     }
   }],
@@ -125,6 +126,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -133,7 +135,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/cos-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/cos-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "cos:fp64"
     }
   }],
@@ -75,6 +76,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -83,7 +85,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/count-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/count-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "count:"
     }
   }],
@@ -61,6 +62,7 @@
           }],
           "measures": [{
             "measure": {
+              "functionReference": 1,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "i64": {

--- a/substrait_consumer/snapshots/producer/function/arithmetic/count_star-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/count_star-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "count:"
     }
   }],
@@ -61,6 +62,7 @@
           }],
           "measures": [{
             "measure": {
+              "functionReference": 1,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "i64": {

--- a/substrait_consumer/snapshots/producer/function/arithmetic/divide-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/divide-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "divide:i64_i64"
     }
   }],
@@ -75,6 +76,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "i64": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/exp-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/exp-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "exp:fp64"
     }
   }],
@@ -84,6 +85,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -92,7 +94,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/max-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/max-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "max:dec"
     }
   }],
@@ -81,6 +82,7 @@
           }],
           "measures": [{
             "measure": {
+              "functionReference": 1,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "decimal": {

--- a/substrait_consumer/snapshots/producer/function/arithmetic/min-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/min-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "min:dec"
     }
   }],
@@ -81,6 +82,7 @@
           }],
           "measures": [{
             "measure": {
+              "functionReference": 1,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "decimal": {

--- a/substrait_consumer/snapshots/producer/function/arithmetic/modulus-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/modulus-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "modulus:i64_i64"
     }
   }],
@@ -75,6 +76,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "i32": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/multiply-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/multiply-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "multiply:i64_i64"
     }
   }],
@@ -75,6 +76,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "i64": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/sign-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/sign-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "sign:i32"
     }
   }],
@@ -69,6 +70,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "i32": {
                       "nullability": "NULLABILITY_NULLABLE"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/sin-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/sin-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "sin:fp64"
     }
   }],
@@ -75,6 +76,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -83,7 +85,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/sqrt-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/sqrt-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "power:fp64_fp64"
     }
   }],
@@ -84,6 +85,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -92,7 +94,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/subtract-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/subtract-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "subtract:i64_i64"
     }
   }],
@@ -85,6 +86,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "i64": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/arithmetic/sum-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/sum-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "sum:dec"
     }
   }],
@@ -81,6 +82,7 @@
           }],
           "measures": [{
             "measure": {
+              "functionReference": 1,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "decimal": {

--- a/substrait_consumer/snapshots/producer/function/arithmetic/tan-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/arithmetic/tan-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "tan:fp64"
     }
   }],
@@ -75,6 +76,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -83,7 +85,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "fp64": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/boolean/and-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/boolean/and-isthmus_plan.json
@@ -9,18 +9,19 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "lt:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "equal:any_any"
     }
   }],
@@ -75,6 +76,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_NULLABLE"
@@ -83,7 +85,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_NULLABLE"
@@ -112,7 +114,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 2,
+                        "functionReference": 3,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_NULLABLE"

--- a/substrait_consumer/snapshots/producer/function/boolean/or-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/boolean/or-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "or:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }],
@@ -69,6 +70,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_NULLABLE"
@@ -77,7 +79,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_NULLABLE"
@@ -106,7 +108,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_NULLABLE"

--- a/substrait_consumer/snapshots/producer/function/comparison/between-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/between-isthmus_plan.json
@@ -9,18 +9,19 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "gte:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "lte:any_any"
     }
   }],
@@ -81,6 +82,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_NULLABLE"
@@ -89,7 +91,7 @@
                       "arguments": [{
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 1,
+                            "functionReference": 2,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_NULLABLE"
@@ -118,7 +120,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 2,
+                            "functionReference": 3,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_NULLABLE"

--- a/substrait_consumer/snapshots/producer/function/comparison/equal-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/equal-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "equal:any_any"
     }
   }],
@@ -66,6 +67,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/comparison/gt-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/gt-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "gt:any_any"
     }
   }],
@@ -72,6 +73,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/comparison/gte-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/gte-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "gte:any_any"
     }
   }],
@@ -72,6 +73,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/comparison/is_not_null-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/is_not_null-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "is_not_null:any"
     }
   }],
@@ -60,6 +61,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/comparison/is_null-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/is_null-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "is_null:any"
     }
   }],
@@ -60,6 +61,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/comparison/lt-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/lt-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "lt:any_any"
     }
   }],
@@ -72,6 +73,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/comparison/lte-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/lte-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "lte:any_any"
     }
   }],
@@ -72,6 +73,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/comparison/not_equal-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/comparison/not_equal-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "not:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }],
@@ -69,6 +70,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -77,7 +79,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/datetime/extract-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/datetime/extract-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "extract:req_date"
     }
   }],
@@ -126,6 +127,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "i64": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/datetime/gt-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/datetime/gt-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "gt:date_date"
     }
   }],
@@ -136,6 +137,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/datetime/gte-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/datetime/gte-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "gte:date_date"
     }
   }],
@@ -136,6 +137,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/datetime/lt-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/datetime/lt-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "lt:date_date"
     }
   }],
@@ -136,6 +137,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/datetime/lte-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/datetime/lte-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "lte:date_date"
     }
   }],
@@ -136,6 +137,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/rounding/ceil-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/rounding/ceil-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "ceil:fp64"
     }
   }],
@@ -76,6 +77,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/rounding/floor-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/rounding/floor-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "floor:fp64"
     }
   }],
@@ -76,6 +77,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/rounding/round-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/rounding/round-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "round:fp64_i32"
     }
   }],
@@ -126,6 +127,7 @@
                 }
               }, {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "fp64": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/string/like-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/string/like-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "like:str_str"
     }
   }],
@@ -60,6 +61,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/function/string/substring1-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/function/string/substring1-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "substring:str_i32_i32"
     }
   }],
@@ -64,6 +65,7 @@
             }
           }, {
             "scalarFunction": {
+              "functionReference": 1,
               "outputType": {
                 "string": {
                   "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/integration/tpch/q01-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q01-isthmus_plan.json
@@ -12,48 +12,49 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "lte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "subtract:date_iday"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "add:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "sum:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "avg:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 7,
+      "functionAnchor": 8,
       "name": "count:"
     }
   }],
@@ -176,6 +177,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -196,7 +198,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "date": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -267,7 +269,7 @@
                     }
                   }, {
                     "scalarFunction": {
-                      "functionReference": 2,
+                      "functionReference": 3,
                       "outputType": {
                         "decimal": {
                           "scale": 4,
@@ -290,7 +292,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 3,
+                            "functionReference": 4,
                             "outputType": {
                               "decimal": {
                                 "scale": 2,
@@ -335,7 +337,7 @@
                     }
                   }, {
                     "scalarFunction": {
-                      "functionReference": 2,
+                      "functionReference": 3,
                       "outputType": {
                         "decimal": {
                           "scale": 6,
@@ -346,7 +348,7 @@
                       "arguments": [{
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 2,
+                            "functionReference": 3,
                             "outputType": {
                               "decimal": {
                                 "scale": 4,
@@ -369,7 +371,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 3,
+                                  "functionReference": 4,
                                   "outputType": {
                                     "decimal": {
                                       "scale": 2,
@@ -416,7 +418,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 4,
+                            "functionReference": 5,
                             "outputType": {
                               "decimal": {
                                 "scale": 2,
@@ -496,7 +498,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 5,
+                  "functionReference": 6,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -522,7 +524,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 5,
+                  "functionReference": 6,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -548,7 +550,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 5,
+                  "functionReference": 6,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -574,7 +576,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 5,
+                  "functionReference": 6,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -600,7 +602,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -626,7 +628,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -652,7 +654,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -678,7 +680,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 7,
+                  "functionReference": 8,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i64": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q02-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q02-isthmus_plan.json
@@ -15,24 +15,25 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "like:str_str"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "min:dec"
     }
   }],
@@ -305,6 +306,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_NULLABLE"
@@ -313,7 +315,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -348,7 +350,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -384,7 +386,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -414,7 +416,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -454,7 +456,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -490,7 +492,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -526,7 +528,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -556,7 +558,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_NULLABLE"
@@ -775,6 +777,7 @@
                                                     },
                                                     "condition": {
                                                       "scalarFunction": {
+                                                        "functionReference": 1,
                                                         "outputType": {
                                                           "bool": {
                                                             "nullability": "NULLABILITY_REQUIRED"
@@ -783,7 +786,7 @@
                                                         "arguments": [{
                                                           "value": {
                                                             "scalarFunction": {
-                                                              "functionReference": 1,
+                                                              "functionReference": 2,
                                                               "outputType": {
                                                                 "bool": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -818,7 +821,7 @@
                                                         }, {
                                                           "value": {
                                                             "scalarFunction": {
-                                                              "functionReference": 1,
+                                                              "functionReference": 2,
                                                               "outputType": {
                                                                 "bool": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -854,7 +857,7 @@
                                                         }, {
                                                           "value": {
                                                             "scalarFunction": {
-                                                              "functionReference": 1,
+                                                              "functionReference": 2,
                                                               "outputType": {
                                                                 "bool": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -890,7 +893,7 @@
                                                         }, {
                                                           "value": {
                                                             "scalarFunction": {
-                                                              "functionReference": 1,
+                                                              "functionReference": 2,
                                                               "outputType": {
                                                                 "bool": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -926,7 +929,7 @@
                                                         }, {
                                                           "value": {
                                                             "scalarFunction": {
-                                                              "functionReference": 1,
+                                                              "functionReference": 2,
                                                               "outputType": {
                                                                 "bool": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -975,7 +978,7 @@
                                             }],
                                             "measures": [{
                                               "measure": {
-                                                "functionReference": 3,
+                                                "functionReference": 4,
                                                 "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                                                 "outputType": {
                                                   "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q03-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q03-isthmus_plan.json
@@ -15,42 +15,43 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "lt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "gt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "sum:dec"
     }
   }],
@@ -310,6 +311,7 @@
                               },
                               "condition": {
                                 "scalarFunction": {
+                                  "functionReference": 1,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -318,7 +320,7 @@
                                   "arguments": [{
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 1,
+                                        "functionReference": 2,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -348,7 +350,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 1,
+                                        "functionReference": 2,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -383,7 +385,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 1,
+                                        "functionReference": 2,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -419,7 +421,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -459,7 +461,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 3,
+                                        "functionReference": 4,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -533,7 +535,7 @@
                             }
                           }, {
                             "scalarFunction": {
-                              "functionReference": 4,
+                              "functionReference": 5,
                               "outputType": {
                                 "decimal": {
                                   "scale": 4,
@@ -556,7 +558,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 5,
+                                    "functionReference": 6,
                                     "outputType": {
                                       "decimal": {
                                         "scale": 2,
@@ -636,7 +638,7 @@
                       }],
                       "measures": [{
                         "measure": {
-                          "functionReference": 6,
+                          "functionReference": 7,
                           "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                           "outputType": {
                             "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q04-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q04-isthmus_plan.json
@@ -15,30 +15,31 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "lt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "count:"
     }
   }],
@@ -127,6 +128,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -135,7 +137,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -175,7 +177,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -315,6 +317,7 @@
                                       },
                                       "condition": {
                                         "scalarFunction": {
+                                          "functionReference": 1,
                                           "outputType": {
                                             "bool": {
                                               "nullability": "NULLABILITY_REQUIRED"
@@ -323,7 +326,7 @@
                                           "arguments": [{
                                             "value": {
                                               "scalarFunction": {
-                                                "functionReference": 3,
+                                                "functionReference": 4,
                                                 "outputType": {
                                                   "bool": {
                                                     "nullability": "NULLABILITY_REQUIRED"
@@ -358,7 +361,7 @@
                                           }, {
                                             "value": {
                                               "scalarFunction": {
-                                                "functionReference": 2,
+                                                "functionReference": 3,
                                                 "outputType": {
                                                   "bool": {
                                                     "nullability": "NULLABILITY_REQUIRED"
@@ -431,7 +434,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 4,
+                  "functionReference": 5,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i64": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q05-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q05-isthmus_plan.json
@@ -15,42 +15,43 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "lt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "sum:dec"
     }
   }],
@@ -433,6 +434,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -441,7 +443,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -476,7 +478,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -512,7 +514,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -548,7 +550,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -584,7 +586,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -620,7 +622,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -656,7 +658,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -686,7 +688,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -726,7 +728,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 4,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -780,7 +782,7 @@
                     }
                   }, {
                     "scalarFunction": {
-                      "functionReference": 4,
+                      "functionReference": 5,
                       "outputType": {
                         "decimal": {
                           "scale": 4,
@@ -803,7 +805,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 5,
+                            "functionReference": 6,
                             "outputType": {
                               "decimal": {
                                 "scale": 2,
@@ -863,7 +865,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q06-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q06-isthmus_plan.json
@@ -15,48 +15,49 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "lt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "gte:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "lte:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "lt:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 7,
+      "functionAnchor": 8,
       "name": "sum:dec"
     }
   }],
@@ -173,6 +174,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_REQUIRED"
@@ -181,7 +183,7 @@
                       "arguments": [{
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 1,
+                            "functionReference": 2,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -221,7 +223,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 2,
+                            "functionReference": 3,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -261,7 +263,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 3,
+                            "functionReference": 4,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -295,7 +297,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 4,
+                            "functionReference": 5,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -329,7 +331,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 5,
+                            "functionReference": 6,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -367,7 +369,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "outputType": {
                     "decimal": {
                       "scale": 4,
@@ -408,7 +410,7 @@
           }],
           "measures": [{
             "measure": {
-              "functionReference": 7,
+              "functionReference": 8,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q07-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q07-isthmus_plan.json
@@ -15,54 +15,55 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "or:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "lte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "extract:req_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 7,
+      "functionAnchor": 8,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 8,
+      "functionAnchor": 9,
       "name": "sum:dec"
     }
   }],
@@ -449,6 +450,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -457,7 +459,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -492,7 +494,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -528,7 +530,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -564,7 +566,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -600,7 +602,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -636,7 +638,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -645,6 +647,7 @@
                                 "arguments": [{
                                   "value": {
                                     "scalarFunction": {
+                                      "functionReference": 1,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -653,7 +656,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 1,
+                                            "functionReference": 2,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -683,7 +686,7 @@
                                       }, {
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 1,
+                                            "functionReference": 2,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -716,6 +719,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
+                                      "functionReference": 1,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -724,7 +728,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 1,
+                                            "functionReference": 2,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -754,7 +758,7 @@
                                       }, {
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 1,
+                                            "functionReference": 2,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -790,7 +794,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 4,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -830,7 +834,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 4,
+                                "functionReference": 5,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -894,7 +898,7 @@
                     }
                   }, {
                     "scalarFunction": {
-                      "functionReference": 5,
+                      "functionReference": 6,
                       "outputType": {
                         "i64": {
                           "nullability": "NULLABILITY_REQUIRED"
@@ -918,7 +922,7 @@
                     }
                   }, {
                     "scalarFunction": {
-                      "functionReference": 6,
+                      "functionReference": 7,
                       "outputType": {
                         "decimal": {
                           "scale": 4,
@@ -941,7 +945,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 7,
+                            "functionReference": 8,
                             "outputType": {
                               "decimal": {
                                 "scale": 2,
@@ -1021,7 +1025,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 8,
+                  "functionReference": 9,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q08-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q08-isthmus_plan.json
@@ -15,54 +15,55 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "lte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "extract:req_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 7,
+      "functionAnchor": 8,
       "name": "sum:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 8,
+      "functionAnchor": 9,
       "name": "divide:dec_dec"
     }
   }],
@@ -558,6 +559,7 @@
                           },
                           "condition": {
                             "scalarFunction": {
+                              "functionReference": 1,
                               "outputType": {
                                 "bool": {
                                   "nullability": "NULLABILITY_REQUIRED"
@@ -566,7 +568,7 @@
                               "arguments": [{
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -601,7 +603,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -637,7 +639,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -673,7 +675,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -709,7 +711,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -745,7 +747,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -781,7 +783,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -811,7 +813,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -847,7 +849,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 2,
+                                    "functionReference": 3,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -887,7 +889,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 3,
+                                    "functionReference": 4,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -927,7 +929,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -961,7 +963,7 @@
                       },
                       "expressions": [{
                         "scalarFunction": {
-                          "functionReference": 4,
+                          "functionReference": 5,
                           "outputType": {
                             "i64": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -988,7 +990,7 @@
                           "ifs": [{
                             "if": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -1017,7 +1019,7 @@
                             },
                             "then": {
                               "scalarFunction": {
-                                "functionReference": 5,
+                                "functionReference": 6,
                                 "outputType": {
                                   "decimal": {
                                     "scale": 4,
@@ -1040,7 +1042,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 6,
+                                      "functionReference": 7,
                                       "outputType": {
                                         "decimal": {
                                           "scale": 2,
@@ -1097,7 +1099,7 @@
                         }
                       }, {
                         "scalarFunction": {
-                          "functionReference": 5,
+                          "functionReference": 6,
                           "outputType": {
                             "decimal": {
                               "scale": 4,
@@ -1120,7 +1122,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 6,
+                                "functionReference": 7,
                                 "outputType": {
                                   "decimal": {
                                     "scale": 2,
@@ -1180,7 +1182,7 @@
                   }],
                   "measures": [{
                     "measure": {
-                      "functionReference": 7,
+                      "functionReference": 8,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "decimal": {
@@ -1206,7 +1208,7 @@
                     }
                   }, {
                     "measure": {
-                      "functionReference": 7,
+                      "functionReference": 8,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "decimal": {
@@ -1244,7 +1246,7 @@
                 }
               }, {
                 "scalarFunction": {
-                  "functionReference": 8,
+                  "functionReference": 9,
                   "outputType": {
                     "decimal": {
                       "scale": 6,

--- a/substrait_consumer/snapshots/producer/integration/tpch/q09-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q09-isthmus_plan.json
@@ -18,42 +18,43 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "like:str_str"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "extract:req_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "sum:dec"
     }
   }],
@@ -450,6 +451,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -458,7 +460,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -494,7 +496,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -530,7 +532,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -566,7 +568,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -601,7 +603,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -637,7 +639,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -673,7 +675,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -727,7 +729,7 @@
                     }
                   }, {
                     "scalarFunction": {
-                      "functionReference": 3,
+                      "functionReference": 4,
                       "outputType": {
                         "i64": {
                           "nullability": "NULLABILITY_REQUIRED"
@@ -751,7 +753,7 @@
                     }
                   }, {
                     "scalarFunction": {
-                      "functionReference": 4,
+                      "functionReference": 5,
                       "outputType": {
                         "decimal": {
                           "scale": 4,
@@ -762,7 +764,7 @@
                       "arguments": [{
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 5,
+                            "functionReference": 6,
                             "outputType": {
                               "decimal": {
                                 "scale": 4,
@@ -785,7 +787,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 4,
+                                  "functionReference": 5,
                                   "outputType": {
                                     "decimal": {
                                       "scale": 2,
@@ -832,7 +834,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 5,
+                            "functionReference": 6,
                             "outputType": {
                               "decimal": {
                                 "scale": 4,
@@ -896,7 +898,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q10-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q10-isthmus_plan.json
@@ -15,42 +15,43 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "lt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "sum:dec"
     }
   }],
@@ -352,6 +353,7 @@
                               },
                               "condition": {
                                 "scalarFunction": {
+                                  "functionReference": 1,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -360,7 +362,7 @@
                                   "arguments": [{
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 1,
+                                        "functionReference": 2,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -395,7 +397,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 1,
+                                        "functionReference": 2,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -431,7 +433,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -471,7 +473,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 3,
+                                        "functionReference": 4,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -511,7 +513,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 1,
+                                        "functionReference": 2,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -541,7 +543,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 1,
+                                        "functionReference": 2,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -650,7 +652,7 @@
                             }
                           }, {
                             "scalarFunction": {
-                              "functionReference": 4,
+                              "functionReference": 5,
                               "outputType": {
                                 "decimal": {
                                   "scale": 4,
@@ -673,7 +675,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 5,
+                                    "functionReference": 6,
                                     "outputType": {
                                       "decimal": {
                                         "scale": 2,
@@ -793,7 +795,7 @@
                       }],
                       "measures": [{
                         "measure": {
-                          "functionReference": 6,
+                          "functionReference": 7,
                           "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                           "outputType": {
                             "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q11-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q11-isthmus_plan.json
@@ -12,30 +12,31 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "sum:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "gt:any_any"
     }
   }],
@@ -212,6 +213,7 @@
                           },
                           "condition": {
                             "scalarFunction": {
+                              "functionReference": 1,
                               "outputType": {
                                 "bool": {
                                   "nullability": "NULLABILITY_REQUIRED"
@@ -220,7 +222,7 @@
                               "arguments": [{
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -256,7 +258,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -292,7 +294,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -335,7 +337,7 @@
                         }
                       }, {
                         "scalarFunction": {
-                          "functionReference": 2,
+                          "functionReference": 3,
                           "outputType": {
                             "decimal": {
                               "scale": 2,
@@ -398,7 +400,7 @@
                   }],
                   "measures": [{
                     "measure": {
-                      "functionReference": 3,
+                      "functionReference": 4,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "decimal": {
@@ -427,7 +429,7 @@
               },
               "condition": {
                 "scalarFunction": {
-                  "functionReference": 4,
+                  "functionReference": 5,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_NULLABLE"
@@ -636,6 +638,7 @@
                                               },
                                               "condition": {
                                                 "scalarFunction": {
+                                                  "functionReference": 1,
                                                   "outputType": {
                                                     "bool": {
                                                       "nullability": "NULLABILITY_REQUIRED"
@@ -644,7 +647,7 @@
                                                   "arguments": [{
                                                     "value": {
                                                       "scalarFunction": {
-                                                        "functionReference": 1,
+                                                        "functionReference": 2,
                                                         "outputType": {
                                                           "bool": {
                                                             "nullability": "NULLABILITY_REQUIRED"
@@ -680,7 +683,7 @@
                                                   }, {
                                                     "value": {
                                                       "scalarFunction": {
-                                                        "functionReference": 1,
+                                                        "functionReference": 2,
                                                         "outputType": {
                                                           "bool": {
                                                             "nullability": "NULLABILITY_REQUIRED"
@@ -716,7 +719,7 @@
                                                   }, {
                                                     "value": {
                                                       "scalarFunction": {
-                                                        "functionReference": 1,
+                                                        "functionReference": 2,
                                                         "outputType": {
                                                           "bool": {
                                                             "nullability": "NULLABILITY_REQUIRED"
@@ -750,7 +753,7 @@
                                           },
                                           "expressions": [{
                                             "scalarFunction": {
-                                              "functionReference": 2,
+                                              "functionReference": 3,
                                               "outputType": {
                                                 "decimal": {
                                                   "scale": 2,
@@ -803,7 +806,7 @@
                                       }],
                                       "measures": [{
                                         "measure": {
-                                          "functionReference": 3,
+                                          "functionReference": 4,
                                           "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                                           "outputType": {
                                             "decimal": {
@@ -831,7 +834,7 @@
                                   },
                                   "expressions": [{
                                     "scalarFunction": {
-                                      "functionReference": 2,
+                                      "functionReference": 3,
                                       "outputType": {
                                         "decimal": {
                                           "scale": 12,

--- a/substrait_consumer/snapshots/producer/integration/tpch/q12-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q12-isthmus_plan.json
@@ -15,42 +15,43 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "or:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "lt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "not_equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "sum:i32"
     }
   }],
@@ -237,6 +238,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -245,7 +247,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -280,7 +282,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -289,7 +291,7 @@
                                 "arguments": [{
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -319,7 +321,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -352,7 +354,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 4,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -388,7 +390,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 4,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -424,7 +426,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 4,
+                                "functionReference": 5,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -464,7 +466,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 4,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -521,7 +523,7 @@
                       "ifs": [{
                         "if": {
                           "scalarFunction": {
-                            "functionReference": 2,
+                            "functionReference": 3,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -530,7 +532,7 @@
                             "arguments": [{
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 1,
+                                  "functionReference": 2,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -560,7 +562,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 1,
+                                  "functionReference": 2,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -607,6 +609,7 @@
                       "ifs": [{
                         "if": {
                           "scalarFunction": {
+                            "functionReference": 1,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -615,7 +618,7 @@
                             "arguments": [{
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 5,
+                                  "functionReference": 6,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -645,7 +648,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 5,
+                                  "functionReference": 6,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -704,7 +707,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i32": {
@@ -728,7 +731,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i32": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q13-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q13-isthmus_plan.json
@@ -15,36 +15,37 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "not:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "like:str_str"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "count:any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "count:"
     }
   }],
@@ -205,6 +206,7 @@
                                   },
                                   "expression": {
                                     "scalarFunction": {
+                                      "functionReference": 1,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -213,7 +215,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 1,
+                                            "functionReference": 2,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -248,7 +250,7 @@
                                       }, {
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 2,
+                                            "functionReference": 3,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -257,7 +259,7 @@
                                             "arguments": [{
                                               "value": {
                                                 "scalarFunction": {
-                                                  "functionReference": 3,
+                                                  "functionReference": 4,
                                                   "outputType": {
                                                     "bool": {
                                                       "nullability": "NULLABILITY_REQUIRED"
@@ -339,7 +341,7 @@
                           }],
                           "measures": [{
                             "measure": {
-                              "functionReference": 4,
+                              "functionReference": 5,
                               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                               "outputType": {
                                 "i64": {
@@ -391,7 +393,7 @@
                   }],
                   "measures": [{
                     "measure": {
-                      "functionReference": 5,
+                      "functionReference": 6,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "i64": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q14-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q14-isthmus_plan.json
@@ -18,54 +18,55 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "lt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "like:str_str"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 7,
+      "functionAnchor": 8,
       "name": "sum:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 8,
+      "functionAnchor": 9,
       "name": "divide:dec_dec"
     }
   }],
@@ -253,6 +254,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -261,7 +263,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -297,7 +299,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -327,7 +329,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 4,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -374,7 +376,7 @@
                       "ifs": [{
                         "if": {
                           "scalarFunction": {
-                            "functionReference": 4,
+                            "functionReference": 5,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -413,7 +415,7 @@
                         },
                         "then": {
                           "scalarFunction": {
-                            "functionReference": 5,
+                            "functionReference": 6,
                             "outputType": {
                               "decimal": {
                                 "scale": 4,
@@ -436,7 +438,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 6,
+                                  "functionReference": 7,
                                   "outputType": {
                                     "decimal": {
                                       "scale": 2,
@@ -493,7 +495,7 @@
                     }
                   }, {
                     "scalarFunction": {
-                      "functionReference": 5,
+                      "functionReference": 6,
                       "outputType": {
                         "decimal": {
                           "scale": 4,
@@ -516,7 +518,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 6,
+                            "functionReference": 7,
                             "outputType": {
                               "decimal": {
                                 "scale": 2,
@@ -566,7 +568,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 7,
+                  "functionReference": 8,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -591,7 +593,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 7,
+                  "functionReference": 8,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -620,7 +622,7 @@
           },
           "expressions": [{
             "scalarFunction": {
-              "functionReference": 8,
+              "functionReference": 9,
               "outputType": {
                 "decimal": {
                   "scale": 6,
@@ -631,7 +633,7 @@
               "arguments": [{
                 "value": {
                   "scalarFunction": {
-                    "functionReference": 5,
+                    "functionReference": 6,
                     "outputType": {
                       "decimal": {
                         "scale": 6,

--- a/substrait_consumer/snapshots/producer/integration/tpch/q16-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q16-isthmus_plan.json
@@ -15,42 +15,43 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "not_equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "not:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "like:str_str"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "or:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "count:any"
     }
   }],
@@ -187,6 +188,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"
@@ -195,7 +197,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -230,7 +232,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -260,7 +262,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 4,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -269,7 +271,7 @@
                                 "arguments": [{
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 4,
+                                      "functionReference": 5,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -312,7 +314,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 5,
+                                "functionReference": 6,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -321,7 +323,7 @@
                                 "arguments": [{
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -351,7 +353,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -381,7 +383,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -411,7 +413,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -441,7 +443,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -471,7 +473,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -501,7 +503,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -531,7 +533,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 1,
+                                      "functionReference": 2,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -564,7 +566,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 4,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -648,7 +650,7 @@
                                                 },
                                                 "condition": {
                                                   "scalarFunction": {
-                                                    "functionReference": 4,
+                                                    "functionReference": 5,
                                                     "outputType": {
                                                       "bool": {
                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -787,7 +789,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i64": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q17-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q17-isthmus_plan.json
@@ -12,42 +12,43 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "lt:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "avg:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "sum:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "divide:dec_dec"
     }
   }],
@@ -235,6 +236,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_NULLABLE"
@@ -243,7 +245,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -279,7 +281,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -309,7 +311,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -339,7 +341,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 3,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_NULLABLE"
@@ -491,7 +493,7 @@
                                                         },
                                                         "condition": {
                                                           "scalarFunction": {
-                                                            "functionReference": 1,
+                                                            "functionReference": 2,
                                                             "outputType": {
                                                               "bool": {
                                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -544,7 +546,7 @@
                                                 }],
                                                 "measures": [{
                                                   "measure": {
-                                                    "functionReference": 3,
+                                                    "functionReference": 4,
                                                     "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                                                     "outputType": {
                                                       "decimal": {
@@ -572,7 +574,7 @@
                                             },
                                             "expressions": [{
                                               "scalarFunction": {
-                                                "functionReference": 4,
+                                                "functionReference": 5,
                                                 "outputType": {
                                                   "decimal": {
                                                     "scale": 3,
@@ -634,7 +636,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 5,
+                  "functionReference": 6,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -662,7 +664,7 @@
           },
           "expressions": [{
             "scalarFunction": {
-              "functionReference": 6,
+              "functionReference": 7,
               "outputType": {
                 "decimal": {
                   "scale": 6,

--- a/substrait_consumer/snapshots/producer/integration/tpch/q18-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q18-isthmus_plan.json
@@ -12,24 +12,25 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "sum:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "gt:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "equal:any_any"
     }
   }],
@@ -282,6 +283,7 @@
                           },
                           "condition": {
                             "scalarFunction": {
+                              "functionReference": 1,
                               "outputType": {
                                 "bool": {
                                   "nullability": "NULLABILITY_REQUIRED"
@@ -454,7 +456,7 @@
                                                   }],
                                                   "measures": [{
                                                     "measure": {
-                                                      "functionReference": 1,
+                                                      "functionReference": 2,
                                                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                                                       "outputType": {
                                                         "decimal": {
@@ -483,7 +485,7 @@
                                               },
                                               "condition": {
                                                 "scalarFunction": {
-                                                  "functionReference": 2,
+                                                  "functionReference": 3,
                                                   "outputType": {
                                                     "bool": {
                                                       "nullability": "NULLABILITY_NULLABLE"
@@ -534,7 +536,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 3,
+                                    "functionReference": 4,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -569,7 +571,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 3,
+                                    "functionReference": 4,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -723,7 +725,7 @@
                   }],
                   "measures": [{
                     "measure": {
-                      "functionReference": 1,
+                      "functionReference": 2,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q19-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q19-isthmus_plan.json
@@ -15,54 +15,55 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "or:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "gte:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "lte:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "add:i32_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 7,
+      "functionAnchor": 8,
       "name": "subtract:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 8,
+      "functionAnchor": 9,
       "name": "sum:dec"
     }
   }],
@@ -243,6 +244,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_REQUIRED"
@@ -251,7 +253,7 @@
                       "arguments": [{
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 1,
+                            "functionReference": 2,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -260,7 +262,7 @@
                             "arguments": [{
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -296,7 +298,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -326,6 +328,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
+                                  "functionReference": 1,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -334,7 +337,7 @@
                                   "arguments": [{
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -364,7 +367,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -394,7 +397,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -424,7 +427,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -457,7 +460,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 3,
+                                  "functionReference": 4,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -491,7 +494,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 4,
+                                  "functionReference": 5,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -521,7 +524,7 @@
                                         },
                                         "input": {
                                           "scalarFunction": {
-                                            "functionReference": 5,
+                                            "functionReference": 6,
                                             "outputType": {
                                               "i32": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -551,7 +554,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 3,
+                                  "functionReference": 4,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -581,7 +584,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 4,
+                                  "functionReference": 5,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -611,6 +614,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
+                                  "functionReference": 1,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -619,7 +623,7 @@
                                   "arguments": [{
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -649,7 +653,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -682,7 +686,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -715,7 +719,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 1,
+                            "functionReference": 2,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -724,7 +728,7 @@
                             "arguments": [{
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -760,7 +764,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -790,6 +794,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
+                                  "functionReference": 1,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -798,7 +803,7 @@
                                   "arguments": [{
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -828,7 +833,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -858,7 +863,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -888,7 +893,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -921,7 +926,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 3,
+                                  "functionReference": 4,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -955,7 +960,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 4,
+                                  "functionReference": 5,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -985,7 +990,7 @@
                                         },
                                         "input": {
                                           "scalarFunction": {
-                                            "functionReference": 5,
+                                            "functionReference": 6,
                                             "outputType": {
                                               "i32": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -1015,7 +1020,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 3,
+                                  "functionReference": 4,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1045,7 +1050,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 4,
+                                  "functionReference": 5,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1075,6 +1080,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
+                                  "functionReference": 1,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1083,7 +1089,7 @@
                                   "arguments": [{
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -1113,7 +1119,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -1146,7 +1152,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1179,7 +1185,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 1,
+                            "functionReference": 2,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -1188,7 +1194,7 @@
                             "arguments": [{
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1224,7 +1230,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1254,6 +1260,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
+                                  "functionReference": 1,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1262,7 +1269,7 @@
                                   "arguments": [{
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -1292,7 +1299,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -1322,7 +1329,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -1352,7 +1359,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -1385,7 +1392,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 3,
+                                  "functionReference": 4,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1419,7 +1426,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 4,
+                                  "functionReference": 5,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1449,7 +1456,7 @@
                                         },
                                         "input": {
                                           "scalarFunction": {
-                                            "functionReference": 5,
+                                            "functionReference": 6,
                                             "outputType": {
                                               "i32": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -1479,7 +1486,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 3,
+                                  "functionReference": 4,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1509,7 +1516,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 4,
+                                  "functionReference": 5,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1539,6 +1546,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
+                                  "functionReference": 1,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1547,7 +1555,7 @@
                                   "arguments": [{
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -1577,7 +1585,7 @@
                                   }, {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 3,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_REQUIRED"
@@ -1610,7 +1618,7 @@
                             }, {
                               "value": {
                                 "scalarFunction": {
-                                  "functionReference": 2,
+                                  "functionReference": 3,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"
@@ -1647,7 +1655,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
-                  "functionReference": 6,
+                  "functionReference": 7,
                   "outputType": {
                     "decimal": {
                       "scale": 4,
@@ -1670,7 +1678,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 7,
+                        "functionReference": 8,
                         "outputType": {
                           "decimal": {
                             "scale": 2,
@@ -1720,7 +1728,7 @@
           }],
           "measures": [{
             "measure": {
-              "functionReference": 8,
+              "functionReference": 9,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "decimal": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q20-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q20-isthmus_plan.json
@@ -18,48 +18,49 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "like:str_str"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "gt:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "gte:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "lt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "sum:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 7,
+      "functionAnchor": 8,
       "name": "multiply:dec_dec"
     }
   }],
@@ -176,6 +177,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_REQUIRED"
@@ -250,6 +252,7 @@
                                       },
                                       "condition": {
                                         "scalarFunction": {
+                                          "functionReference": 1,
                                           "outputType": {
                                             "bool": {
                                               "nullability": "NULLABILITY_NULLABLE"
@@ -340,7 +343,7 @@
                                                           },
                                                           "condition": {
                                                             "scalarFunction": {
-                                                              "functionReference": 1,
+                                                              "functionReference": 2,
                                                               "outputType": {
                                                                 "bool": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -397,7 +400,7 @@
                                           }, {
                                             "value": {
                                               "scalarFunction": {
-                                                "functionReference": 2,
+                                                "functionReference": 3,
                                                 "outputType": {
                                                   "bool": {
                                                     "nullability": "NULLABILITY_NULLABLE"
@@ -558,6 +561,7 @@
                                                                             },
                                                                             "condition": {
                                                                               "scalarFunction": {
+                                                                                "functionReference": 1,
                                                                                 "outputType": {
                                                                                   "bool": {
                                                                                     "nullability": "NULLABILITY_REQUIRED"
@@ -566,7 +570,7 @@
                                                                                 "arguments": [{
                                                                                   "value": {
                                                                                     "scalarFunction": {
-                                                                                      "functionReference": 3,
+                                                                                      "functionReference": 4,
                                                                                       "outputType": {
                                                                                         "bool": {
                                                                                           "nullability": "NULLABILITY_REQUIRED"
@@ -602,7 +606,7 @@
                                                                                 }, {
                                                                                   "value": {
                                                                                     "scalarFunction": {
-                                                                                      "functionReference": 3,
+                                                                                      "functionReference": 4,
                                                                                       "outputType": {
                                                                                         "bool": {
                                                                                           "nullability": "NULLABILITY_REQUIRED"
@@ -639,7 +643,7 @@
                                                                                 }, {
                                                                                   "value": {
                                                                                     "scalarFunction": {
-                                                                                      "functionReference": 4,
+                                                                                      "functionReference": 5,
                                                                                       "outputType": {
                                                                                         "bool": {
                                                                                           "nullability": "NULLABILITY_REQUIRED"
@@ -679,7 +683,7 @@
                                                                                 }, {
                                                                                   "value": {
                                                                                     "scalarFunction": {
-                                                                                      "functionReference": 5,
+                                                                                      "functionReference": 6,
                                                                                       "outputType": {
                                                                                         "bool": {
                                                                                           "nullability": "NULLABILITY_REQUIRED"
@@ -738,7 +742,7 @@
                                                                     }],
                                                                     "measures": [{
                                                                       "measure": {
-                                                                        "functionReference": 6,
+                                                                        "functionReference": 7,
                                                                         "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                                                                         "outputType": {
                                                                           "decimal": {
@@ -766,7 +770,7 @@
                                                                 },
                                                                 "expressions": [{
                                                                   "scalarFunction": {
-                                                                    "functionReference": 7,
+                                                                    "functionReference": 8,
                                                                     "outputType": {
                                                                       "decimal": {
                                                                         "scale": 3,
@@ -833,7 +837,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 3,
+                            "functionReference": 4,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -869,7 +873,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 3,
+                            "functionReference": 4,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/integration/tpch/q21-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q21-isthmus_plan.json
@@ -15,36 +15,37 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "gt:date_date"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "not_equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "not:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "count:"
     }
   }],
@@ -335,6 +336,7 @@
                           },
                           "condition": {
                             "scalarFunction": {
+                              "functionReference": 1,
                               "outputType": {
                                 "bool": {
                                   "nullability": "NULLABILITY_REQUIRED"
@@ -343,7 +345,7 @@
                               "arguments": [{
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -378,7 +380,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -414,7 +416,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -444,7 +446,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 2,
+                                    "functionReference": 3,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -580,6 +582,7 @@
                                           },
                                           "condition": {
                                             "scalarFunction": {
+                                              "functionReference": 1,
                                               "outputType": {
                                                 "bool": {
                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -588,7 +591,7 @@
                                               "arguments": [{
                                                 "value": {
                                                   "scalarFunction": {
-                                                    "functionReference": 1,
+                                                    "functionReference": 2,
                                                     "outputType": {
                                                       "bool": {
                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -624,7 +627,7 @@
                                               }, {
                                                 "value": {
                                                   "scalarFunction": {
-                                                    "functionReference": 3,
+                                                    "functionReference": 4,
                                                     "outputType": {
                                                       "bool": {
                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -669,7 +672,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 4,
+                                    "functionReference": 5,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -778,6 +781,7 @@
                                                 },
                                                 "condition": {
                                                   "scalarFunction": {
+                                                    "functionReference": 1,
                                                     "outputType": {
                                                       "bool": {
                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -786,7 +790,7 @@
                                                     "arguments": [{
                                                       "value": {
                                                         "scalarFunction": {
-                                                          "functionReference": 1,
+                                                          "functionReference": 2,
                                                           "outputType": {
                                                             "bool": {
                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -822,7 +826,7 @@
                                                     }, {
                                                       "value": {
                                                         "scalarFunction": {
-                                                          "functionReference": 3,
+                                                          "functionReference": 4,
                                                           "outputType": {
                                                             "bool": {
                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -859,7 +863,7 @@
                                                     }, {
                                                       "value": {
                                                         "scalarFunction": {
-                                                          "functionReference": 2,
+                                                          "functionReference": 3,
                                                           "outputType": {
                                                             "bool": {
                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -906,7 +910,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -942,7 +946,7 @@
                               }, {
                                 "value": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_REQUIRED"
@@ -1001,7 +1005,7 @@
                   }],
                   "measures": [{
                     "measure": {
-                      "functionReference": 5,
+                      "functionReference": 6,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "i64": {

--- a/substrait_consumer/snapshots/producer/integration/tpch/q22-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/integration/tpch/q22-isthmus_plan.json
@@ -18,54 +18,55 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "or:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 3,
-      "functionAnchor": 3,
+      "functionAnchor": 4,
       "name": "substring:str_i32_i32"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 4,
+      "functionAnchor": 5,
       "name": "gt:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 5,
+      "functionAnchor": 6,
       "name": "avg:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 6,
+      "functionAnchor": 7,
       "name": "not:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 5,
-      "functionAnchor": 7,
+      "functionAnchor": 8,
       "name": "count:"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 4,
-      "functionAnchor": 8,
+      "functionAnchor": 9,
       "name": "sum:dec"
     }
   }],
@@ -150,6 +151,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_NULLABLE"
@@ -158,7 +160,7 @@
                           "arguments": [{
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 1,
+                                "functionReference": 2,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -167,7 +169,7 @@
                                 "arguments": [{
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 2,
+                                      "functionReference": 3,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -176,7 +178,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 3,
+                                            "functionReference": 4,
                                             "outputType": {
                                               "string": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -221,7 +223,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 2,
+                                      "functionReference": 3,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -230,7 +232,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 3,
+                                            "functionReference": 4,
                                             "outputType": {
                                               "string": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -275,7 +277,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 2,
+                                      "functionReference": 3,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -284,7 +286,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 3,
+                                            "functionReference": 4,
                                             "outputType": {
                                               "string": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -329,7 +331,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 2,
+                                      "functionReference": 3,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -338,7 +340,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 3,
+                                            "functionReference": 4,
                                             "outputType": {
                                               "string": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -383,7 +385,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 2,
+                                      "functionReference": 3,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -392,7 +394,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 3,
+                                            "functionReference": 4,
                                             "outputType": {
                                               "string": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -437,7 +439,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 2,
+                                      "functionReference": 3,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -446,7 +448,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 3,
+                                            "functionReference": 4,
                                             "outputType": {
                                               "string": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -491,7 +493,7 @@
                                 }, {
                                   "value": {
                                     "scalarFunction": {
-                                      "functionReference": 2,
+                                      "functionReference": 3,
                                       "outputType": {
                                         "bool": {
                                           "nullability": "NULLABILITY_REQUIRED"
@@ -500,7 +502,7 @@
                                       "arguments": [{
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 3,
+                                            "functionReference": 4,
                                             "outputType": {
                                               "string": {
                                                 "nullability": "NULLABILITY_REQUIRED"
@@ -548,7 +550,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 4,
+                                "functionReference": 5,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_NULLABLE"
@@ -643,6 +645,7 @@
                                                     },
                                                     "condition": {
                                                       "scalarFunction": {
+                                                        "functionReference": 1,
                                                         "outputType": {
                                                           "bool": {
                                                             "nullability": "NULLABILITY_REQUIRED"
@@ -651,7 +654,7 @@
                                                         "arguments": [{
                                                           "value": {
                                                             "scalarFunction": {
-                                                              "functionReference": 4,
+                                                              "functionReference": 5,
                                                               "outputType": {
                                                                 "bool": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -685,7 +688,7 @@
                                                         }, {
                                                           "value": {
                                                             "scalarFunction": {
-                                                              "functionReference": 1,
+                                                              "functionReference": 2,
                                                               "outputType": {
                                                                 "bool": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
@@ -694,7 +697,7 @@
                                                               "arguments": [{
                                                                 "value": {
                                                                   "scalarFunction": {
-                                                                    "functionReference": 2,
+                                                                    "functionReference": 3,
                                                                     "outputType": {
                                                                       "bool": {
                                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -703,7 +706,7 @@
                                                                     "arguments": [{
                                                                       "value": {
                                                                         "scalarFunction": {
-                                                                          "functionReference": 3,
+                                                                          "functionReference": 4,
                                                                           "outputType": {
                                                                             "string": {
                                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -748,7 +751,7 @@
                                                               }, {
                                                                 "value": {
                                                                   "scalarFunction": {
-                                                                    "functionReference": 2,
+                                                                    "functionReference": 3,
                                                                     "outputType": {
                                                                       "bool": {
                                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -757,7 +760,7 @@
                                                                     "arguments": [{
                                                                       "value": {
                                                                         "scalarFunction": {
-                                                                          "functionReference": 3,
+                                                                          "functionReference": 4,
                                                                           "outputType": {
                                                                             "string": {
                                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -802,7 +805,7 @@
                                                               }, {
                                                                 "value": {
                                                                   "scalarFunction": {
-                                                                    "functionReference": 2,
+                                                                    "functionReference": 3,
                                                                     "outputType": {
                                                                       "bool": {
                                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -811,7 +814,7 @@
                                                                     "arguments": [{
                                                                       "value": {
                                                                         "scalarFunction": {
-                                                                          "functionReference": 3,
+                                                                          "functionReference": 4,
                                                                           "outputType": {
                                                                             "string": {
                                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -856,7 +859,7 @@
                                                               }, {
                                                                 "value": {
                                                                   "scalarFunction": {
-                                                                    "functionReference": 2,
+                                                                    "functionReference": 3,
                                                                     "outputType": {
                                                                       "bool": {
                                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -865,7 +868,7 @@
                                                                     "arguments": [{
                                                                       "value": {
                                                                         "scalarFunction": {
-                                                                          "functionReference": 3,
+                                                                          "functionReference": 4,
                                                                           "outputType": {
                                                                             "string": {
                                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -910,7 +913,7 @@
                                                               }, {
                                                                 "value": {
                                                                   "scalarFunction": {
-                                                                    "functionReference": 2,
+                                                                    "functionReference": 3,
                                                                     "outputType": {
                                                                       "bool": {
                                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -919,7 +922,7 @@
                                                                     "arguments": [{
                                                                       "value": {
                                                                         "scalarFunction": {
-                                                                          "functionReference": 3,
+                                                                          "functionReference": 4,
                                                                           "outputType": {
                                                                             "string": {
                                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -964,7 +967,7 @@
                                                               }, {
                                                                 "value": {
                                                                   "scalarFunction": {
-                                                                    "functionReference": 2,
+                                                                    "functionReference": 3,
                                                                     "outputType": {
                                                                       "bool": {
                                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -973,7 +976,7 @@
                                                                     "arguments": [{
                                                                       "value": {
                                                                         "scalarFunction": {
-                                                                          "functionReference": 3,
+                                                                          "functionReference": 4,
                                                                           "outputType": {
                                                                             "string": {
                                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -1018,7 +1021,7 @@
                                                               }, {
                                                                 "value": {
                                                                   "scalarFunction": {
-                                                                    "functionReference": 2,
+                                                                    "functionReference": 3,
                                                                     "outputType": {
                                                                       "bool": {
                                                                         "nullability": "NULLABILITY_REQUIRED"
@@ -1027,7 +1030,7 @@
                                                                     "arguments": [{
                                                                       "value": {
                                                                         "scalarFunction": {
-                                                                          "functionReference": 3,
+                                                                          "functionReference": 4,
                                                                           "outputType": {
                                                                             "string": {
                                                                               "nullability": "NULLABILITY_REQUIRED"
@@ -1094,7 +1097,7 @@
                                             }],
                                             "measures": [{
                                               "measure": {
-                                                "functionReference": 5,
+                                                "functionReference": 6,
                                                 "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                                                 "outputType": {
                                                   "decimal": {
@@ -1129,7 +1132,7 @@
                           }, {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 6,
+                                "functionReference": 7,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_REQUIRED"
@@ -1204,7 +1207,7 @@
                                             },
                                             "condition": {
                                               "scalarFunction": {
-                                                "functionReference": 2,
+                                                "functionReference": 3,
                                                 "outputType": {
                                                   "bool": {
                                                     "nullability": "NULLABILITY_REQUIRED"
@@ -1252,7 +1255,7 @@
                   },
                   "expressions": [{
                     "scalarFunction": {
-                      "functionReference": 3,
+                      "functionReference": 4,
                       "outputType": {
                         "string": {
                           "nullability": "NULLABILITY_REQUIRED"
@@ -1311,7 +1314,7 @@
               }],
               "measures": [{
                 "measure": {
-                  "functionReference": 7,
+                  "functionReference": 8,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i64": {
@@ -1322,7 +1325,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 8,
+                  "functionReference": 9,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {

--- a/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_in_subquery-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_in_subquery-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "lte:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "avg:dec"
     }
   }],
@@ -91,6 +92,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_NULLABLE"
@@ -198,7 +200,7 @@
                               }],
                               "measures": [{
                                 "measure": {
-                                  "functionReference": 1,
+                                  "functionReference": 2,
                                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                                   "outputType": {
                                     "decimal": {

--- a/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_computation-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_computation-isthmus_plan.json
@@ -6,12 +6,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "avg:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "multiply:dec_dec"
     }
   }],
@@ -110,6 +111,7 @@
               }],
               "measures": [{
                 "measure": {
+                  "functionReference": 1,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -137,7 +139,7 @@
           },
           "expressions": [{
             "scalarFunction": {
-              "functionReference": 1,
+              "functionReference": 2,
               "outputType": {
                 "decimal": {
                   "scale": 2,

--- a/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_group_by-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_group_by-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "count:"
     }
   }],
@@ -166,6 +167,7 @@
               }],
               "measures": [{
                 "measure": {
+                  "functionReference": 1,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i64": {

--- a/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_group_by_cube-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_group_by_cube-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "count:"
     }
   }],
@@ -190,6 +191,7 @@
               }],
               "measures": [{
                 "measure": {
+                  "functionReference": 1,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i64": {

--- a/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_group_by_rollup-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_group_by_rollup-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "count:"
     }
   }],
@@ -178,6 +179,7 @@
               }],
               "measures": [{
                 "measure": {
+                  "functionReference": 1,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "i64": {

--- a/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_grouping_set-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/aggregate_with_grouping_set-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "sum:dec"
     }
   }],
@@ -185,6 +186,7 @@
                   }],
                   "measures": [{
                     "measure": {
+                      "functionReference": 1,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "decimal": {

--- a/substrait_consumer/snapshots/producer/relation/aggregate/computation_between_aggregates-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/computation_between_aggregates-isthmus_plan.json
@@ -6,18 +6,19 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "avg:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "max:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "add:dec_dec"
     }
   }],
@@ -116,6 +117,7 @@
               }],
               "measures": [{
                 "measure": {
+                  "functionReference": 1,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -140,7 +142,7 @@
                 }
               }, {
                 "measure": {
-                  "functionReference": 1,
+                  "functionReference": 2,
                   "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                   "outputType": {
                     "decimal": {
@@ -168,7 +170,7 @@
           },
           "expressions": [{
             "scalarFunction": {
-              "functionReference": 2,
+              "functionReference": 3,
               "outputType": {
                 "decimal": {
                   "scale": 2,

--- a/substrait_consumer/snapshots/producer/relation/aggregate/compute_within_aggregate-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/compute_within_aggregate-isthmus_plan.json
@@ -6,12 +6,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "multiply:dec_dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "avg:dec"
     }
   }],
@@ -88,6 +89,7 @@
               },
               "expressions": [{
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "decimal": {
                       "scale": 2,
@@ -134,7 +136,7 @@
           }],
           "measures": [{
             "measure": {
-              "functionReference": 1,
+              "functionReference": 2,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "decimal": {

--- a/substrait_consumer/snapshots/producer/relation/aggregate/multiple_measure_aggregate-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/multiple_measure_aggregate-isthmus_plan.json
@@ -6,18 +6,19 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "min:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "max:dec"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 1,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "avg:dec"
     }
   }],
@@ -109,30 +110,6 @@
           }],
           "measures": [{
             "measure": {
-              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-              "outputType": {
-                "decimal": {
-                  "scale": 2,
-                  "precision": 15,
-                  "nullability": "NULLABILITY_NULLABLE"
-                }
-              },
-              "invocation": "AGGREGATION_INVOCATION_ALL",
-              "arguments": [{
-                "value": {
-                  "selection": {
-                    "directReference": {
-                      "structField": {
-                      }
-                    },
-                    "rootReference": {
-                    }
-                  }
-                }
-              }]
-            }
-          }, {
-            "measure": {
               "functionReference": 1,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
@@ -159,6 +136,31 @@
           }, {
             "measure": {
               "functionReference": 2,
+              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+              "outputType": {
+                "decimal": {
+                  "scale": 2,
+                  "precision": 15,
+                  "nullability": "NULLABILITY_NULLABLE"
+                }
+              },
+              "invocation": "AGGREGATION_INVOCATION_ALL",
+              "arguments": [{
+                "value": {
+                  "selection": {
+                    "directReference": {
+                      "structField": {
+                      }
+                    },
+                    "rootReference": {
+                    }
+                  }
+                }
+              }]
+            }
+          }, {
+            "measure": {
+              "functionReference": 3,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "decimal": {

--- a/substrait_consumer/snapshots/producer/relation/aggregate/single_measure_aggregate-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/aggregate/single_measure_aggregate-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "count:"
     }
   }],
@@ -111,6 +112,7 @@
           }],
           "measures": [{
             "measure": {
+              "functionReference": 1,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "i64": {

--- a/substrait_consumer/snapshots/producer/relation/filter/having-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/having-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "count:"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "gt:any_any"
     }
   }],
@@ -162,6 +163,7 @@
                   }],
                   "measures": [{
                     "measure": {
+                      "functionReference": 1,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "i64": {
@@ -175,7 +177,7 @@
               },
               "condition": {
                 "scalarFunction": {
-                  "functionReference": 1,
+                  "functionReference": 2,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_and-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_and-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }],
@@ -125,6 +126,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -133,7 +135,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"
@@ -162,7 +164,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_between-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_between-isthmus_plan.json
@@ -9,18 +9,19 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "gte:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "lte:any_any"
     }
   }],
@@ -137,6 +138,7 @@
                   },
                   "condition": {
                     "scalarFunction": {
+                      "functionReference": 1,
                       "outputType": {
                         "bool": {
                           "nullability": "NULLABILITY_REQUIRED"
@@ -145,7 +147,7 @@
                       "arguments": [{
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 1,
+                            "functionReference": 2,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"
@@ -174,7 +176,7 @@
                       }, {
                         "value": {
                           "scalarFunction": {
-                            "functionReference": 2,
+                            "functionReference": 3,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_equal_multi_col-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_equal_multi_col-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "equal:any_any"
     }
   }],
@@ -128,6 +129,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_gt_multi_col-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_gt_multi_col-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "gt:any_any"
     }
   }],
@@ -128,6 +129,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_gte_multi_col-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_gte_multi_col-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "gte:any_any"
     }
   }],
@@ -128,6 +129,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_in-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_in-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "or:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }],
@@ -125,6 +126,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -133,7 +135,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"
@@ -162,7 +164,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"
@@ -191,7 +193,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_like-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_like-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "like:str_str"
     }
   }],
@@ -128,6 +129,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_lt_multi_col-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_lt_multi_col-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "lt:any_any"
     }
   }],
@@ -128,6 +129,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_lte_multi_col-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_lte_multi_col-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "lte:any_any"
     }
   }],
@@ -128,6 +129,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_not_equal_multi_col-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_not_equal_multi_col-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "not_equal:any_any"
     }
   }],
@@ -128,6 +129,7 @@
                       },
                       "condition": {
                         "scalarFunction": {
+                          "functionReference": 1,
                           "outputType": {
                             "bool": {
                               "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/filter/where_or-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/filter/where_or-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "or:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }],
@@ -125,6 +126,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -133,7 +135,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"
@@ -162,7 +164,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/full_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/full_join-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "equal:any_any"
     }
   }],
@@ -134,6 +135,7 @@
               },
               "expression": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/inner_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/inner_join-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "equal:any_any"
     }
   }],
@@ -134,6 +135,7 @@
               },
               "expression": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/left_anti_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/left_anti_join-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "not:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }],
@@ -87,6 +88,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -161,7 +163,7 @@
                               },
                               "condition": {
                                 "scalarFunction": {
-                                  "functionReference": 1,
+                                  "functionReference": 2,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/left_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/left_join-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "equal:any_any"
     }
   }],
@@ -134,6 +135,7 @@
               },
               "expression": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/left_semi_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/left_semi_join-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "equal:any_any"
     }
   }],
@@ -144,6 +145,7 @@
                         },
                         "condition": {
                           "scalarFunction": {
+                            "functionReference": 1,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/left_single_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/left_single_join-isthmus_plan.json
@@ -9,18 +9,19 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "not_equal:any_any"
     }
   }],
@@ -145,6 +146,7 @@
               },
               "expression": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -153,7 +155,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"
@@ -189,7 +191,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 2,
+                        "functionReference": 3,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/right_anti_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/right_anti_join-isthmus_plan.json
@@ -9,12 +9,13 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "not:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }],
@@ -91,6 +92,7 @@
               },
               "condition": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -199,7 +201,7 @@
                               },
                               "condition": {
                                 "scalarFunction": {
-                                  "functionReference": 1,
+                                  "functionReference": 2,
                                   "outputType": {
                                     "bool": {
                                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/right_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/right_join-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "equal:any_any"
     }
   }],
@@ -134,6 +135,7 @@
               },
               "expression": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/right_semi_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/right_semi_join-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "equal:any_any"
     }
   }],
@@ -144,6 +145,7 @@
                         },
                         "condition": {
                           "scalarFunction": {
+                            "functionReference": 1,
                             "outputType": {
                               "bool": {
                                 "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/join/right_single_join-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/join/right_single_join-isthmus_plan.json
@@ -9,18 +9,19 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "and:bool"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 1,
+      "functionAnchor": 2,
       "name": "equal:any_any"
     }
   }, {
     "extensionFunction": {
       "extensionUriReference": 2,
-      "functionAnchor": 2,
+      "functionAnchor": 3,
       "name": "not_equal:any_any"
     }
   }],
@@ -145,6 +146,7 @@
               },
               "expression": {
                 "scalarFunction": {
+                  "functionReference": 1,
                   "outputType": {
                     "bool": {
                       "nullability": "NULLABILITY_REQUIRED"
@@ -153,7 +155,7 @@
                   "arguments": [{
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 1,
+                        "functionReference": 2,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"
@@ -189,7 +191,7 @@
                   }, {
                     "value": {
                       "scalarFunction": {
-                        "functionReference": 2,
+                        "functionReference": 3,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_REQUIRED"

--- a/substrait_consumer/snapshots/producer/relation/project/count_distinct_in_project-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/project/count_distinct_in_project-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "count:any"
     }
   }],
@@ -131,6 +132,7 @@
           }],
           "measures": [{
             "measure": {
+              "functionReference": 1,
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
               "outputType": {
                 "i64": {

--- a/substrait_consumer/snapshots/producer/relation/project/extended_project-isthmus_plan.json
+++ b/substrait_consumer/snapshots/producer/relation/project/extended_project-isthmus_plan.json
@@ -6,6 +6,7 @@
   "extensions": [{
     "extensionFunction": {
       "extensionUriReference": 1,
+      "functionAnchor": 1,
       "name": "multiply:dec_dec"
     }
   }],
@@ -120,6 +121,7 @@
             }
           }, {
             "scalarFunction": {
+              "functionReference": 1,
               "outputType": {
                 "decimal": {
                   "scale": 2,


### PR DESCRIPTION
This PR updates the `substrait-java` submodule to the next version, which breaks the tests, namely substrait-io/substrait-java@007accf. The breakages are due to substrait-io/substrait-java#408, which changes the index at which anchors start, which basically changes every plan that Isthmus produces.