### PR TITLE
chore(deps): bump substrait-validator 0.1.1 -> 0.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ PyYAML==6.0.2
 six==1.16.0
 sqlglot==25.20.2
 substrait==0.23.0
-substrait-validator==0.1.1
+substrait-validator==0.1.4
 toolz==0.12.1
 typing_extensions==4.12.2
 tzdata==2024.2


### PR DESCRIPTION
## Summary

Bumps **substrait-validator** from `0.1.1` to `0.1.4`.

## Changes

- `requirements.txt`: substrait-validator `0.1.1` → `0.1.4`

## Testing

Verified import works correctly with the new version.