### PR TITLE
chore(deps): bump protobuf from 5.28.3 to 5.29.6

### DIFF
--- a/requirements-unlocked.txt
+++ b/requirements-unlocked.txt
@@ -5,7 +5,7 @@ ibis-framework
 ibis-substrait
 JPype1
 pandas
-protobuf==5.28.3
+protobuf==5.29.6
 pyarrow
 pytest
 pytest-csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ packaging==24.2
 pandas==2.2.3
 parsy==2.1
 pluggy==1.5.0
-protobuf==5.28.3
+protobuf==5.29.6
 pyarrow==23.0.1
 pytest==8.3.3
 pytest-csv==3.0.0


### PR DESCRIPTION
Forwarding the Dependabot update from the bvolpato fork: https://github.com/bvolpato/consumer-testing/pull/1

Summary:
- Bumps `protobuf` from `5.28.3` to `5.29.6`.
- Updates `requirements.txt` and `requirements-unlocked.txt`.

Risk:
- Protobuf runtime changes can affect generated message parsing/serialization behavior.
- This is a small dependency-only diff, but upstream CI should validate package compatibility.

Tests:
- Not run locally. Relying on upstream CI for this forwarded dependency PR.